### PR TITLE
Feat/remove verify

### DIFF
--- a/helpers/contracts-deployments.ts
+++ b/helpers/contracts-deployments.ts
@@ -57,37 +57,31 @@ const readArtifact = async (id: string) => {
   return (DRE as HardhatRuntimeEnvironment).artifacts.readArtifact(id);
 };
 
-export const deployPoolAddressesProvider = async (marketId: string, verify?: boolean) =>
+export const deployPoolAddressesProvider = async (marketId: string) =>
   withSave(
     await new PoolAddressesProviderFactory(await getFirstSigner()).deploy(marketId),
-    eContractid.PoolAddressesProvider,
-    [marketId],
-    verify
+    eContractid.PoolAddressesProvider
   );
 
-export const deployPoolAddressesProviderRegistry = async (verify?: boolean) =>
+export const deployPoolAddressesProviderRegistry = async () =>
   withSave(
     await new PoolAddressesProviderRegistryFactory(await getFirstSigner()).deploy(),
-    eContractid.PoolAddressesProviderRegistry,
-    [],
-    verify
+    eContractid.PoolAddressesProviderRegistry
   );
 
-export const deployPoolConfigurator = async (verify?: boolean) => {
+export const deployPoolConfigurator = async () => {
   const poolConfiguratorImpl = await new PoolConfiguratorFactory(await getFirstSigner()).deploy();
   await insertContractAddressInDb(eContractid.PoolConfiguratorImpl, poolConfiguratorImpl.address);
-  return withSave(poolConfiguratorImpl, eContractid.PoolConfigurator, [], verify);
+  return withSave(poolConfiguratorImpl, eContractid.PoolConfigurator);
 };
 
-export const deployReserveLogicLibrary = async (verify?: boolean) =>
+export const deployReserveLogicLibrary = async () =>
   withSave(
     await new ReserveLogicFactory(await getFirstSigner()).deploy(),
-    eContractid.ReserveLogic,
-    [],
-    verify
+    eContractid.ReserveLogic
   );
 
-export const deployGenericLogic = async (reserveLogic: Contract, verify?: boolean) => {
+export const deployGenericLogic = async (reserveLogic: Contract) => {
   const genericLogicArtifact = await readArtifact(eContractid.GenericLogic);
 
   const linkedGenericLogicByteCode = linkBytecode(genericLogicArtifact, {
@@ -102,14 +96,10 @@ export const deployGenericLogic = async (reserveLogic: Contract, verify?: boolea
   const genericLogic = await (
     await genericLogicFactory.connect(await getFirstSigner()).deploy()
   ).deployed();
-  return withSave(genericLogic, eContractid.GenericLogic, [], verify);
+  return withSave(genericLogic, eContractid.GenericLogic);
 };
 
-export const deployValidationLogic = async (
-  reserveLogic: Contract,
-  genericLogic: Contract,
-  verify?: boolean
-) => {
+export const deployValidationLogic = async (reserveLogic: Contract, genericLogic: Contract) => {
   const validationLogicArtifact = await readArtifact(eContractid.ValidationLogic);
 
   const linkedValidationLogicByteCode = linkBytecode(validationLogicArtifact, {
@@ -126,13 +116,13 @@ export const deployValidationLogic = async (
     await validationLogicFactory.connect(await getFirstSigner()).deploy()
   ).deployed();
 
-  return withSave(validationLogic, eContractid.ValidationLogic, [], verify);
+  return withSave(validationLogic, eContractid.ValidationLogic);
 };
 
-export const deployAaveLibraries = async (verify?: boolean): Promise<PoolLibraryAddresses> => {
-  const reserveLogic = await deployReserveLogicLibrary(verify);
-  const genericLogic = await deployGenericLogic(reserveLogic, verify);
-  const validationLogic = await deployValidationLogic(reserveLogic, genericLogic, verify);
+export const deployAaveLibraries = async (): Promise<PoolLibraryAddresses> => {
+  const reserveLogic = await deployReserveLogicLibrary();
+  const genericLogic = await deployGenericLogic(reserveLogic);
+  const validationLogic = await deployValidationLogic(reserveLogic, genericLogic);
 
   // Hardcoded solidity placeholders, if any library changes path this will fail.
   // The '__$PLACEHOLDER$__ can be calculated via solidity keccak, but the PoolLibraryAddresses Type seems to
@@ -152,49 +142,34 @@ export const deployAaveLibraries = async (verify?: boolean): Promise<PoolLibrary
   };
 };
 
-export const deployPool = async (verify?: boolean) => {
-  const libraries = await deployAaveLibraries(verify);
+export const deployPool = async () => {
+  const libraries = await deployAaveLibraries();
   const poolImpl = await new PoolFactory(libraries, await getFirstSigner()).deploy();
   await insertContractAddressInDb(eContractid.PoolImpl, poolImpl.address);
-  return withSave(poolImpl, eContractid.Pool, [], verify);
+  return withSave(poolImpl, eContractid.Pool);
 };
 
-export const deployPriceOracle = async (verify?: boolean) =>
-  withSave(
-    await new PriceOracleFactory(await getFirstSigner()).deploy(),
-    eContractid.PriceOracle,
-    [],
-    verify
-  );
+export const deployPriceOracle = async () =>
+  withSave(await new PriceOracleFactory(await getFirstSigner()).deploy(), eContractid.PriceOracle);
 
-export const deployRateOracle = async (verify?: boolean) =>
-  withSave(
-    await new RateOracleFactory(await getFirstSigner()).deploy(),
-    eContractid.RateOracle,
-    [],
-    verify
-  );
+export const deployRateOracle = async () =>
+  withSave(await new RateOracleFactory(await getFirstSigner()).deploy(), eContractid.RateOracle);
 
-export const deployMockAggregator = async (price: tStringTokenSmallUnits, verify?: boolean) =>
+export const deployMockAggregator = async (price: tStringTokenSmallUnits) =>
   withSave(
     await new MockAggregatorFactory(await getFirstSigner()).deploy(price),
-    eContractid.MockAggregator,
-    [price],
-    verify
+    eContractid.MockAggregator
   );
 
 export const deployAaveOracle = async (
-  args: [tEthereumAddress[], tEthereumAddress[], tEthereumAddress, tEthereumAddress, string],
-  verify?: boolean
+  args: [tEthereumAddress[], tEthereumAddress[], tEthereumAddress, tEthereumAddress, string]
 ) =>
   withSave(
     await new AaveOracleFactory(await getFirstSigner()).deploy(...args),
-    eContractid.AaveOracle,
-    args,
-    verify
+    eContractid.AaveOracle
   );
 
-export const deployPoolCollateralManager = async (verify?: boolean) => {
+export const deployPoolCollateralManager = async () => {
   const collateralManagerImpl = await new PoolCollateralManagerFactory(
     await getFirstSigner()
   ).deploy();
@@ -202,128 +177,66 @@ export const deployPoolCollateralManager = async (verify?: boolean) => {
     eContractid.PoolCollateralManagerImpl,
     collateralManagerImpl.address
   );
-  return withSave(collateralManagerImpl, eContractid.PoolCollateralManager, [], verify);
+  return withSave(collateralManagerImpl, eContractid.PoolCollateralManager);
 };
 
-export const deployMockFlashLoanReceiver = async (
-  addressesProvider: tEthereumAddress,
-  verify?: boolean
-) =>
+export const deployMockFlashLoanReceiver = async (addressesProvider: tEthereumAddress) =>
   withSave(
     await new MockFlashLoanReceiverFactory(await getFirstSigner()).deploy(addressesProvider),
-    eContractid.MockFlashLoanReceiver,
-    [addressesProvider],
-    verify
+    eContractid.MockFlashLoanReceiver
   );
 
-export const deployAaveProtocolDataProvider = async (
-  addressesProvider: tEthereumAddress,
-  verify?: boolean
-) =>
+export const deployAaveProtocolDataProvider = async (addressesProvider: tEthereumAddress) =>
   withSave(
     await new AaveProtocolDataProviderFactory(await getFirstSigner()).deploy(addressesProvider),
-    eContractid.AaveProtocolDataProvider,
-    [addressesProvider],
-    verify
+    eContractid.AaveProtocolDataProvider
   );
 
-export const deployMintableERC20 = async (
-  args: [string, string, string],
-  verify?: boolean
-): Promise<MintableERC20> =>
+export const deployMintableERC20 = async (args: [string, string, string]): Promise<MintableERC20> =>
   withSave(
     await new MintableERC20Factory(await getFirstSigner()).deploy(...args),
-    eContractid.MintableERC20,
-    args,
-    verify
+    eContractid.MintableERC20
   );
 
 export const deployMintableDelegationERC20 = async (
-  args: [string, string, string],
-  verify?: boolean
+  args: [string, string, string]
 ): Promise<MintableDelegationERC20> =>
   withSave(
     await new MintableDelegationERC20Factory(await getFirstSigner()).deploy(...args),
-    eContractid.MintableDelegationERC20,
-    args,
-    verify
+    eContractid.MintableDelegationERC20
   );
+
 export const deployDefaultReserveInterestRateStrategy = async (
-  args: [tEthereumAddress, string, string, string, string, string, string],
-  verify: boolean
+  args: [tEthereumAddress, string, string, string, string, string, string]
 ) =>
   withSave(
     await new DefaultReserveInterestRateStrategyFactory(await getFirstSigner()).deploy(...args),
-    eContractid.DefaultReserveInterestRateStrategy,
-    args,
-    verify
+    eContractid.DefaultReserveInterestRateStrategy
   );
-
-//TO-DO remove?
-// export const deployStableDebtToken = async (
-//   args: [tEthereumAddress, tEthereumAddress, tEthereumAddress, string, string],
-//   verify: boolean
-// ) => {
-//   const instance = await withSave(
-//     await new StableDebtTokenFactory(await getFirstSigner()).deploy(),
-//     eContractid.StableDebtToken,
-//     [],
-//     verify
-//   );
-
-//   await instance.initialize(args[0], args[1], args[2], '18', args[3], args[4], '0x10');
-
-//   return instance;
-// };
-
-// export const deployVariableDebtToken = async (
-//   args: [tEthereumAddress, tEthereumAddress, tEthereumAddress, string, string],
-//   verify: boolean
-// ) => {
-//   const instance = await withSave(
-//     await new VariableDebtTokenFactory(await getFirstSigner()).deploy(),
-//     eContractid.VariableDebtToken,
-//     [],
-//     verify
-//   );
-
-//   await instance.initialize(args[0], args[1], args[2], '18', args[3], args[4], '0x10');
-
-//   return instance;
-// };
 
 export const deployGenericStableDebtToken = async () =>
   withSave(
     await new StableDebtTokenFactory(await getFirstSigner()).deploy(),
-    eContractid.StableDebtToken,
-    [],
-    false
+    eContractid.StableDebtToken
   );
 
 export const deployGenericVariableDebtToken = async () =>
   withSave(
     await new VariableDebtTokenFactory(await getFirstSigner()).deploy(),
-    eContractid.VariableDebtToken,
-    [],
-    false
+    eContractid.VariableDebtToken
   );
 
-export const deployGenericAToken = async (
-  [poolAddress, underlyingAssetAddress, treasuryAddress, incentivesController, name, symbol]: [
-    tEthereumAddress,
-    tEthereumAddress,
-    tEthereumAddress,
-    tEthereumAddress,
-    string,
-    string
-  ],
-  verify: boolean
-) => {
+export const deployGenericAToken = async ([
+  poolAddress,
+  underlyingAssetAddress,
+  treasuryAddress,
+  incentivesController,
+  name,
+  symbol,
+]: [tEthereumAddress, tEthereumAddress, tEthereumAddress, tEthereumAddress, string, string]) => {
   const instance = await withSave(
     await new ATokenFactory(await getFirstSigner()).deploy(),
-    eContractid.AToken,
-    [],
-    verify
+    eContractid.AToken
   );
 
   await instance.initialize(
@@ -340,30 +253,20 @@ export const deployGenericAToken = async (
   return instance;
 };
 
-export const deployGenericATokenImpl = async (verify: boolean) =>
-  withSave(
-    await new ATokenFactory(await getFirstSigner()).deploy(),
-    eContractid.AToken,
-    [],
-    verify
-  );
+export const deployGenericATokenImpl = async () =>
+  withSave(await new ATokenFactory(await getFirstSigner()).deploy(), eContractid.AToken);
 
-export const deployDelegationAwareAToken = async (
-  [pool, underlyingAssetAddress, treasuryAddress, incentivesController, name, symbol]: [
-    tEthereumAddress,
-    tEthereumAddress,
-    tEthereumAddress,
-    tEthereumAddress,
-    string,
-    string
-  ],
-  verify: boolean
-) => {
+export const deployDelegationAwareAToken = async ([
+  pool,
+  underlyingAssetAddress,
+  treasuryAddress,
+  incentivesController,
+  name,
+  symbol,
+]: [tEthereumAddress, tEthereumAddress, tEthereumAddress, tEthereumAddress, string, string]) => {
   const instance = await withSave(
     await new DelegationAwareATokenFactory(await getFirstSigner()).deploy(),
-    eContractid.DelegationAwareAToken,
-    [],
-    verify
+    eContractid.DelegationAwareAToken
   );
 
   await instance.initialize(
@@ -380,15 +283,13 @@ export const deployDelegationAwareAToken = async (
   return instance;
 };
 
-export const deployDelegationAwareATokenImpl = async (verify: boolean) =>
+export const deployDelegationAwareATokenImpl = async () =>
   withSave(
     await new DelegationAwareATokenFactory(await getFirstSigner()).deploy(),
-    eContractid.DelegationAwareAToken,
-    [],
-    verify
+    eContractid.DelegationAwareAToken
   );
 
-export const deployAllMockTokens = async (verify?: boolean) => {
+export const deployAllMockTokens = async () => {
   const tokens: { [symbol: string]: MockContract | MintableERC20 } = {};
 
   const protoConfigData = AaveConfig.ReserveAssets;
@@ -398,46 +299,38 @@ export const deployAllMockTokens = async (verify?: boolean) => {
 
     let configData = (<any>protoConfigData)[tokenSymbol];
 
-    tokens[tokenSymbol] = await deployMintableERC20(
-      [tokenSymbol, tokenSymbol, configData ? configData.reserveDecimals : decimals],
-      verify
-    );
+    tokens[tokenSymbol] = await deployMintableERC20([
+      tokenSymbol,
+      tokenSymbol,
+      configData ? configData.reserveDecimals : decimals,
+    ]);
     await registerContractInJsonDb(tokenSymbol.toUpperCase(), tokens[tokenSymbol]);
   }
   return tokens;
 };
 
 export const deployStableAndVariableTokensHelper = async (
-  args: [tEthereumAddress, tEthereumAddress],
-  verify?: boolean
+  args: [tEthereumAddress, tEthereumAddress]
 ) =>
   withSave(
     await new StableAndVariableTokensHelperFactory(await getFirstSigner()).deploy(...args),
-    eContractid.StableAndVariableTokensHelper,
-    args,
-    verify
+    eContractid.StableAndVariableTokensHelper
   );
 
 export const deployATokensAndRatesHelper = async (
-  args: [tEthereumAddress, tEthereumAddress, tEthereumAddress],
-  verify?: boolean
+  args: [tEthereumAddress, tEthereumAddress, tEthereumAddress]
 ) =>
   withSave(
     await new ATokensAndRatesHelperFactory(await getFirstSigner()).deploy(...args),
-    eContractid.ATokensAndRatesHelper,
-    args,
-    verify
+    eContractid.ATokensAndRatesHelper
   );
 
 export const deployMockStableDebtToken = async (
-  args: [tEthereumAddress, tEthereumAddress, tEthereumAddress, string, string, string],
-  verify?: boolean
+  args: [tEthereumAddress, tEthereumAddress, tEthereumAddress, string, string, string]
 ) => {
   const instance = await withSave(
     await new MockStableDebtTokenFactory(await getFirstSigner()).deploy(),
-    eContractid.MockStableDebtToken,
-    [],
-    verify
+    eContractid.MockStableDebtToken
   );
 
   await instance.initialize(args[0], args[1], args[2], '18', args[3], args[4], args[5]);
@@ -445,23 +338,15 @@ export const deployMockStableDebtToken = async (
   return instance;
 };
 
-export const deployWETHMocked = async (verify?: boolean) =>
-  withSave(
-    await new WETH9MockedFactory(await getFirstSigner()).deploy(),
-    eContractid.WETHMocked,
-    [],
-    verify
-  );
+export const deployWETHMocked = async () =>
+  withSave(await new WETH9MockedFactory(await getFirstSigner()).deploy(), eContractid.WETHMocked);
 
 export const deployMockVariableDebtToken = async (
-  args: [tEthereumAddress, tEthereumAddress, tEthereumAddress, string, string, string],
-  verify?: boolean
+  args: [tEthereumAddress, tEthereumAddress, tEthereumAddress, string, string, string]
 ) => {
   const instance = await withSave(
     await new MockVariableDebtTokenFactory(await getFirstSigner()).deploy(),
-    eContractid.MockVariableDebtToken,
-    [],
-    verify
+    eContractid.MockVariableDebtToken
   );
 
   await instance.initialize(args[0], args[1], args[2], '18', args[3], args[4], args[5]);
@@ -478,14 +363,11 @@ export const deployMockAToken = async (
     string,
     string,
     string
-  ],
-  verify?: boolean
+  ]
 ) => {
   const instance = await withSave(
     await new MockATokenFactory(await getFirstSigner()).deploy(),
-    eContractid.MockAToken,
-    [],
-    verify
+    eContractid.MockAToken
   );
 
   await instance.initialize(args[0], args[2], args[1], args[3], '18', args[4], args[5], args[6]);
@@ -493,10 +375,8 @@ export const deployMockAToken = async (
   return instance;
 };
 
-export const deployMockUniswapRouter = async (verify?: boolean) =>
+export const deployMockUniswapRouter = async () =>
   withSave(
     await new MockUniswapV2Router02Factory(await getFirstSigner()).deploy(),
-    eContractid.MockUniswapV2Router02,
-    [],
-    verify
+    eContractid.MockUniswapV2Router02
   );

--- a/helpers/contracts-helpers.ts
+++ b/helpers/contracts-helpers.ts
@@ -63,9 +63,7 @@ export const getEthersSignersAddresses = async (): Promise<tEthereumAddress[]> =
 
 export const withSave = async <ContractType extends Contract>(
   instance: ContractType,
-  id: string,
-  args: (string | string[])[],
-  verify?: boolean
+  id: string
 ): Promise<ContractType> => {
   await waitForTx(instance.deployTransaction);
   await registerContractInJsonDb(id, instance);

--- a/helpers/init-helpers.ts
+++ b/helpers/init-helpers.ts
@@ -1,6 +1,6 @@
 import { eContractid, iMultiPoolsAssets, IReserveParams, tEthereumAddress } from './types';
 import { AaveProtocolDataProvider } from '../types/AaveProtocolDataProvider';
-import { chunk, waitForTx } from './misc-utils';
+import { chunk, getDb, waitForTx } from './misc-utils';
 import {
   getATokensAndRatesHelper,
   getPoolAddressesProvider,
@@ -26,8 +26,7 @@ export const initReservesByHelper = async (
   symbolPrefix: string,
   admin: tEthereumAddress,
   treasuryAddress: tEthereumAddress,
-  incentivesController: tEthereumAddress,
-  verify: boolean
+  incentivesController: tEthereumAddress
 ): Promise<BigNumber> => {
   let gasUsage = BigNumber.from('0');
   const stableAndVariableDeployer = await getStableAndVariableTokensHelper();
@@ -94,7 +93,7 @@ export const initReservesByHelper = async (
   stableDebtTokenImplementationAddress = await (await deployGenericStableDebtToken()).address;
   variableDebtTokenImplementationAddress = await (await deployGenericVariableDebtToken()).address;
 
-  const aTokenImplementation = await deployGenericATokenImpl(verify);
+  const aTokenImplementation = await deployGenericATokenImpl();
   aTokenImplementationAddress = aTokenImplementation.address;
   rawInsertContractAddressInDb(`aTokenImpl`, aTokenImplementationAddress);
 
@@ -103,7 +102,7 @@ export const initReservesByHelper = async (
   ) as [string, IReserveParams][];
 
   if (delegatedAwareReserves.length > 0) {
-    const delegationAwareATokenImplementation = await deployDelegationAwareATokenImpl(verify);
+    const delegationAwareATokenImplementation = await deployDelegationAwareATokenImpl();
     delegationAwareATokenImplementationAddress = delegationAwareATokenImplementation.address;
     rawInsertContractAddressInDb(
       `delegationAwareATokenImpl`,
@@ -142,7 +141,7 @@ export const initReservesByHelper = async (
         stableRateSlope2,
       ];
       strategyAddresses[strategy.name] = (
-        await deployDefaultReserveInterestRateStrategy(rateStrategies[strategy.name], verify)
+        await deployDefaultReserveInterestRateStrategy(rateStrategies[strategy.name])
       ).address;
       // This causes the last strategy to be printed twice, once under "DefaultReserveInterestRateStrategy"
       // and once under the actual `strategyASSET` key.

--- a/helpers/oracles-helpers.ts
+++ b/helpers/oracles-helpers.ts
@@ -80,10 +80,7 @@ export const setInitialAssetPricesInOracle = async (
   }
 };
 
-export const deployAllMockAggregators = async (
-  initialPrices: iAssetAggregatorBase<string>,
-  verify?: boolean
-) => {
+export const deployAllMockAggregators = async (initialPrices: iAssetAggregatorBase<string>) => {
   const aggregators: { [tokenSymbol: string]: MockAggregator } = {};
   for (const tokenContractName of Object.keys(initialPrices)) {
     if (tokenContractName !== 'ETH') {
@@ -91,7 +88,7 @@ export const deployAllMockAggregators = async (
         (value) => value === tokenContractName
       );
       const [, price] = (Object.entries(initialPrices) as [string, string][])[priceIndex];
-      aggregators[tokenContractName] = await deployMockAggregator(price, verify);
+      aggregators[tokenContractName] = await deployMockAggregator(price);
     }
   }
   return aggregators;

--- a/helpers/tenderly-utils.ts
+++ b/helpers/tenderly-utils.ts
@@ -6,12 +6,3 @@ export const usingTenderly = () =>
   DRE &&
   ((DRE as HardhatRuntimeEnvironment).network.name.includes('tenderly') ||
     process.env.TENDERLY === 'true');
-
-export const verifyAtTenderly = async (id: string, instance: Contract) => {
-  console.log('\n- Doing Tenderly contract verification of', id);
-  await (DRE as any).tenderlyNetwork.verify({
-    name: id,
-    address: instance.address,
-  });
-  console.log(`  - Verified ${id} at Tenderly!`);
-};

--- a/tasks/dev/1_mock_tokens.ts
+++ b/tasks/dev/1_mock_tokens.ts
@@ -1,9 +1,9 @@
 import { task } from 'hardhat/config';
 import { deployAllMockTokens } from '../../helpers/contracts-deployments';
 
-task('dev:deploy-mock-tokens', 'Deploy mock tokens for dev enviroment')
-  .addFlag('verify', 'Verify contracts at Etherscan')
-  .setAction(async ({ verify }, localBRE) => {
+task('dev:deploy-mock-tokens', 'Deploy mock tokens for dev enviroment').setAction(
+  async (_, localBRE) => {
     await localBRE.run('set-DRE');
-    await deployAllMockTokens(verify);
-  });
+    await deployAllMockTokens();
+  }
+);

--- a/tasks/dev/2_address_provider_registry.ts
+++ b/tasks/dev/2_address_provider_registry.ts
@@ -10,19 +10,17 @@ import AaveConfig from '../../market-config';
 task(
   'dev:deploy-address-provider',
   'Deploy address provider, registry and fee provider for dev enviroment'
-)
-  .addFlag('verify', 'Verify contracts at Etherscan')
-  .setAction(async ({ verify }, localBRE) => {
-    await localBRE.run('set-DRE');
+).setAction(async (_, localBRE) => {
+  await localBRE.run('set-DRE');
 
-    const admin = await (await getEthersSigners())[0].getAddress();
+  const admin = await (await getEthersSigners())[0].getAddress();
 
-    const addressesProvider = await deployPoolAddressesProvider(AaveConfig.MarketId, verify);
-    await waitForTx(await addressesProvider.setPoolAdmin(admin));
-    await waitForTx(await addressesProvider.setEmergencyAdmin(admin));
+  const addressesProvider = await deployPoolAddressesProvider(AaveConfig.MarketId);
+  await waitForTx(await addressesProvider.setPoolAdmin(admin));
+  await waitForTx(await addressesProvider.setEmergencyAdmin(admin));
 
-    const addressesProviderRegistry = await deployPoolAddressesProviderRegistry(verify);
-    await waitForTx(
-      await addressesProviderRegistry.registerAddressesProvider(addressesProvider.address, 1)
-    );
-  });
+  const addressesProviderRegistry = await deployPoolAddressesProviderRegistry();
+  await waitForTx(
+    await addressesProviderRegistry.registerAddressesProvider(addressesProvider.address, 1)
+  );
+});

--- a/tasks/dev/3_pool.ts
+++ b/tasks/dev/3_pool.ts
@@ -14,40 +14,36 @@ import {
 } from '../../helpers/contracts-getters';
 import { insertContractAddressInDb } from '../../helpers/contracts-helpers';
 
-task('dev:deploy-pool', 'Deploy pool for dev enviroment')
-  .addFlag('verify', 'Verify contracts at Etherscan')
-  .setAction(async ({ verify }, localBRE) => {
-    await localBRE.run('set-DRE');
+task('dev:deploy-pool', 'Deploy pool for dev enviroment').setAction(async (_, localBRE) => {
+  await localBRE.run('set-DRE');
 
-    const addressesProvider = await getPoolAddressesProvider();
+  const addressesProvider = await getPoolAddressesProvider();
 
-    const poolImpl = await deployPool(verify);
+  const poolImpl = await deployPool();
 
-    // Set pool impl to Address Provider
-    await waitForTx(await addressesProvider.setPoolImpl(poolImpl.address));
+  // Set pool impl to Address Provider
+  await waitForTx(await addressesProvider.setPoolImpl(poolImpl.address));
 
-    const address = await addressesProvider.getPool();
-    const poolProxy = await getPool(address);
+  const address = await addressesProvider.getPool();
+  const poolProxy = await getPool(address);
 
-    await insertContractAddressInDb(eContractid.Pool, poolProxy.address);
+  await insertContractAddressInDb(eContractid.Pool, poolProxy.address);
 
-    const poolConfiguratorImpl = await deployPoolConfigurator(verify);
+  const poolConfiguratorImpl = await deployPoolConfigurator();
 
-    // Set pool conf impl to Address Provider
-    await waitForTx(await addressesProvider.setPoolConfiguratorImpl(poolConfiguratorImpl.address));
+  // Set pool conf impl to Address Provider
+  await waitForTx(await addressesProvider.setPoolConfiguratorImpl(poolConfiguratorImpl.address));
 
-    const poolConfiguratorProxy = await getPoolConfiguratorProxy(
-      await addressesProvider.getPoolConfigurator()
-    );
-    await insertContractAddressInDb(eContractid.PoolConfigurator, poolConfiguratorProxy.address);
+  const poolConfiguratorProxy = await getPoolConfiguratorProxy(
+    await addressesProvider.getPoolConfigurator()
+  );
+  await insertContractAddressInDb(eContractid.PoolConfigurator, poolConfiguratorProxy.address);
 
-    // Deploy deployment helpers
-    await deployStableAndVariableTokensHelper(
-      [poolProxy.address, addressesProvider.address],
-      verify
-    );
-    await deployATokensAndRatesHelper(
-      [poolProxy.address, addressesProvider.address, poolConfiguratorProxy.address],
-      verify
-    );
-  });
+  // Deploy deployment helpers
+  await deployStableAndVariableTokensHelper([poolProxy.address, addressesProvider.address]);
+  await deployATokensAndRatesHelper([
+    poolProxy.address,
+    addressesProvider.address,
+    poolConfiguratorProxy.address,
+  ]);
+});

--- a/tasks/dev/5_initialize.ts
+++ b/tasks/dev/5_initialize.ts
@@ -15,60 +15,47 @@ import { getAllMockedTokens, getPoolAddressesProvider } from '../../helpers/cont
 import { insertContractAddressInDb } from '../../helpers/contracts-helpers';
 import AaveConfig from '../../market-config';
 
-task('dev:initialize-pool', 'Initialize pool configuration.')
-  .addFlag('verify', 'Verify contracts at Etherscan')
-  .setAction(async ({ verify }, localBRE) => {
-    await localBRE.run('set-DRE');
-    const network = <eNetwork>localBRE.network.name;
-    const poolConfig = AaveConfig;
-    const {
-      ATokenNamePrefix,
-      StableDebtTokenNamePrefix,
-      VariableDebtTokenNamePrefix,
-      SymbolPrefix,
-    } = poolConfig;
-    const mockTokens = await getAllMockedTokens();
-    const allTokenAddresses = getAllTokenAddresses(mockTokens);
+task('dev:initialize-pool', 'Initialize pool configuration.').setAction(async (_, localBRE) => {
+  await localBRE.run('set-DRE');
+  const network = <eNetwork>localBRE.network.name;
+  const poolConfig = AaveConfig;
+  const { ATokenNamePrefix, StableDebtTokenNamePrefix, VariableDebtTokenNamePrefix, SymbolPrefix } =
+    poolConfig;
+  const mockTokens = await getAllMockedTokens();
+  const allTokenAddresses = getAllTokenAddresses(mockTokens);
 
-    const addressesProvider = await getPoolAddressesProvider();
+  const addressesProvider = await getPoolAddressesProvider();
 
-    const protoPoolReservesAddresses = <{ [symbol: string]: tEthereumAddress }>(
-      filterMapBy(allTokenAddresses, (key: string) => !key.includes('UNI_'))
-    );
+  const protoPoolReservesAddresses = <{ [symbol: string]: tEthereumAddress }>(
+    filterMapBy(allTokenAddresses, (key: string) => !key.includes('UNI_'))
+  );
 
-    const testHelpers = await deployAaveProtocolDataProvider(addressesProvider.address, verify);
+  const testHelpers = await deployAaveProtocolDataProvider(addressesProvider.address);
 
-    const reservesParams = poolConfig.ReservesConfig;
+  const reservesParams = poolConfig.ReservesConfig;
 
-    const admin = await addressesProvider.getPoolAdmin();
+  const admin = await addressesProvider.getPoolAdmin();
 
-    const treasuryAddress = poolConfig.ReserveFactorTreasuryAddress;
+  const treasuryAddress = poolConfig.ReserveFactorTreasuryAddress;
 
-    await initReservesByHelper(
-      reservesParams,
-      protoPoolReservesAddresses,
-      ATokenNamePrefix,
-      StableDebtTokenNamePrefix,
-      VariableDebtTokenNamePrefix,
-      SymbolPrefix,
-      admin,
-      treasuryAddress,
-      ZERO_ADDRESS,
-      verify
-    );
-    await configureReservesByHelper(reservesParams, protoPoolReservesAddresses, testHelpers, admin);
+  await initReservesByHelper(
+    reservesParams,
+    protoPoolReservesAddresses,
+    ATokenNamePrefix,
+    StableDebtTokenNamePrefix,
+    VariableDebtTokenNamePrefix,
+    SymbolPrefix,
+    admin,
+    treasuryAddress,
+    ZERO_ADDRESS
+  );
+  await configureReservesByHelper(reservesParams, protoPoolReservesAddresses, testHelpers, admin);
 
-    const collateralManager = await deployPoolCollateralManager(verify);
-    await waitForTx(await addressesProvider.setPoolCollateralManager(collateralManager.address));
+  const collateralManager = await deployPoolCollateralManager();
+  await waitForTx(await addressesProvider.setPoolCollateralManager(collateralManager.address));
 
-    const mockFlashLoanReceiver = await deployMockFlashLoanReceiver(
-      addressesProvider.address,
-      verify
-    );
-    await insertContractAddressInDb(
-      eContractid.MockFlashLoanReceiver,
-      mockFlashLoanReceiver.address
-    );
+  const mockFlashLoanReceiver = await deployMockFlashLoanReceiver(addressesProvider.address);
+  await insertContractAddressInDb(eContractid.MockFlashLoanReceiver, mockFlashLoanReceiver.address);
 
-    await insertContractAddressInDb(eContractid.AaveProtocolDataProvider, testHelpers.address);
-  });
+  await insertContractAddressInDb(eContractid.AaveProtocolDataProvider, testHelpers.address);
+});


### PR DESCRIPTION
The scripts to verify on etherscan were removed, but some legacy code existing as if this were still an option.

Removed remaining code pertaining to verifying contracts on etherscan / tenderly