### PR TITLE
fix: Change ordering in `executeRepay` to save gas

### DIFF
--- a/contracts/protocol/libraries/logic/BorrowLogic.sol
+++ b/contracts/protocol/libraries/logic/BorrowLogic.sol
@@ -153,10 +153,9 @@ library BorrowLogic {
     DataTypes.ExecuteRepayParams memory params
   ) external returns (uint256) {
     DataTypes.ReserveCache memory reserveCache = reserve.cache();
-    DataTypes.InterestRateMode interestRateMode = DataTypes.InterestRateMode(params.rateMode);
-
     reserve.updateState(reserveCache);
 
+    DataTypes.InterestRateMode interestRateMode = DataTypes.InterestRateMode(params.rateMode);
     (uint256 stableDebt, uint256 variableDebt) = Helpers.getUserCurrentDebt(
       params.onBehalfOf,
       reserve


### PR DESCRIPTION
Closes #170 