### PR TITLE
fix: Implement simplification

### DIFF
--- a/contracts/protocol/pool/Pool.sol
+++ b/contracts/protocol/pool/Pool.sol
@@ -417,7 +417,7 @@ contract Pool is VersionedInitializable, IPool, PoolStorage {
         reserve.accruedToTreasury = 0;
         uint256 normalizedIncome = reserve.getNormalizedIncome();
         uint256 amountToMint = accruedToTreasury.rayMul(normalizedIncome);
-        IAToken(reserve.aTokenAddress).mintToTreasury(accruedToTreasury, normalizedIncome);
+        IAToken(reserve.aTokenAddress).mintToTreasury(amountToMint, normalizedIncome);
 
         emit MintedToTreasury(assetAddress, amountToMint);
       }

--- a/contracts/protocol/tokenization/AToken.sol
+++ b/contracts/protocol/tokenization/AToken.sol
@@ -133,7 +133,7 @@ contract AToken is VersionedInitializable, IncentivizedERC20, IAToken {
     address user,
     uint256 amount,
     uint256 index
-  ) external override onlyPool returns (bool) {
+  ) public override onlyPool returns (bool) {
     uint256 amountScaled = amount.rayDiv(index);
     require(amountScaled != 0, Errors.CT_INVALID_MINT_AMOUNT);
 
@@ -156,18 +156,7 @@ contract AToken is VersionedInitializable, IncentivizedERC20, IAToken {
     if (amount == 0) {
       return;
     }
-
-    address treasury = _treasury;
-
-    // Compared to the normal mint, we don't check for rounding errors.
-    // The amount to mint can easily be very small since it is a fraction of the interest ccrued.
-    // In that case, the treasury will experience a (very small) loss, but it
-    // wont cause potentially valid transactions to fail.
-    _mint(treasury, Helpers.castUint128(amount));
-
-    uint256 amountToMint = amount.rayMul(index);
-    emit Transfer(address(0), treasury, amountToMint);
-    emit Mint(treasury, amountToMint, index);
+    mint(_treasury, amount, index);
   }
 
   /// @inheritdoc IAToken


### PR DESCRIPTION
The simplification works well looking at the storage updates in isolation, but the `A*B` values is required for the `MintedToTreasury` event in `Pool::mintToTreasury()` and the `Transfer` and `Mint` events in the `AToken::mintToTreasury()`. Meaning that the simplification will essentially replace a `rayDiv` with an extra variable and a `rayMul` in `AToken::mintToTreasury()` while just passing another value in `Pool::mintToTreasury()`. 
Overall gas usage has negligible increase `~6 gas`. 

Closes #187 