### PR TITLE
Add decimals to MockAggregator to match Chainlink Aggregator interface

### DIFF
--- a/contracts/mocks/oracle/CLAggregators/MockAggregator.sol
+++ b/contracts/mocks/oracle/CLAggregators/MockAggregator.sol
@@ -18,4 +18,8 @@ contract MockAggregator {
   function getTokenType() external pure returns (uint256) {
     return 1;
   }
+
+  function decimals() external pure returns (uint8) {
+    return 8;
+  }
 }


### PR DESCRIPTION
- Add pure function `decimals() returns (uint8)`  that returns `8` at MockAggregator to match Chainlink Aggregator interface
