### PR TITLE
fix: update counter variable type

### DIFF
--- a/contracts/protocol/pool/Pool.sol
+++ b/contracts/protocol/pool/Pool.sol
@@ -734,11 +734,10 @@ contract Pool is VersionedInitializable, IPool, PoolStorage {
     require(!reserveAlreadyAdded, Errors.RL_RESERVE_ALREADY_INITIALIZED);
 
     uint16 reservesCount = _reservesCount;
-
-    for (uint16 i = 0; i < reservesCount; i++) {
-      if (_reservesList[i] == address(0)) {
-        _reserves[asset].id = i;
-        _reservesList[i] = asset;
+    for (uint256 i = 0; i < reservesCount; i++) {
+      if (_reservesList[uint16(i)] == address(0)) {
+        _reserves[asset].id = uint16(i);
+        _reservesList[uint16(i)] = asset;
         return;
       }
     }


### PR DESCRIPTION
closes #437 

Introduces minor gas savings in the initReserve (min 31, max 156, avg 87). Makes the code less readable given that the uint256 counter needs to be re-cast to a uint 16.