### PR TITLE
fix: Remove redundant functions in WadRayMath lib

### DIFF
--- a/contracts/mocks/tests/WadRayMathWrapper.sol
+++ b/contracts/mocks/tests/WadRayMathWrapper.sol
@@ -5,7 +5,7 @@ import {WadRayMath} from '../../protocol/libraries/math/WadRayMath.sol';
 
 contract WadRayMathWrapper {
   function wad() public pure returns (uint256) {
-    return WadRayMath.wad();
+    return WadRayMath.WAD;
   }
 
   function ray() public pure returns (uint256) {
@@ -13,11 +13,11 @@ contract WadRayMathWrapper {
   }
 
   function halfRay() public pure returns (uint256) {
-    return WadRayMath.halfRay();
+    return WadRayMath.HALF_RAY;
   }
 
   function halfWad() public pure returns (uint256) {
-    return WadRayMath.halfWad();
+    return WadRayMath.HALF_WAD;
   }
 
   function wadMul(uint256 a, uint256 b) public pure returns (uint256) {

--- a/contracts/protocol/libraries/math/WadRayMath.sol
+++ b/contracts/protocol/libraries/math/WadRayMath.sol
@@ -12,32 +12,10 @@ library WadRayMath {
   uint256 internal constant WAD = 1e18;
   uint256 internal constant HALF_WAD = 0.5e18;
 
-  uint256 public constant RAY = 1e27;
+  uint256 internal constant RAY = 1e27;
   uint256 internal constant HALF_RAY = 0.5e27;
 
   uint256 internal constant WAD_RAY_RATIO = 1e9;
-
-  /**
-   * @return One wad, 1e18
-   **/
-
-  function wad() internal pure returns (uint256) {
-    return WAD;
-  }
-
-  /**
-   * @return Half ray, 1e27/2
-   **/
-  function halfRay() internal pure returns (uint256) {
-    return HALF_RAY;
-  }
-
-  /**
-   * @return Half ray, 1e18/2
-   **/
-  function halfWad() internal pure returns (uint256) {
-    return HALF_WAD;
-  }
 
   /**
    * @dev Multiplies two wad, rounding half up to the nearest wad


### PR DESCRIPTION
Closes #505 