### PR TITLE
fix: Remove unneeded _getUnderlyingAsset()

### DIFF
--- a/contracts/protocol/tokenization/StableDebtToken.sol
+++ b/contracts/protocol/tokenization/StableDebtToken.sol
@@ -34,8 +34,6 @@ contract StableDebtToken is IStableDebtToken, DebtTokenBase {
   // Timestamp of the last update of the total supply
   uint40 _totalSupplyTimestamp;
 
-  address internal _underlyingAsset;
-
   /**
    * @dev Constructor.
    * @param pool The address of the Pool contract
@@ -324,11 +322,6 @@ contract StableDebtToken is IStableDebtToken, DebtTokenBase {
    * @return The address of the underlying asset
    **/
   function UNDERLYING_ASSET_ADDRESS() external view returns (address) {
-    return _underlyingAsset;
-  }
-
-  /// @inheritdoc DebtTokenBase
-  function _getUnderlyingAssetAddress() internal view override returns (address) {
     return _underlyingAsset;
   }
 

--- a/contracts/protocol/tokenization/VariableDebtToken.sol
+++ b/contracts/protocol/tokenization/VariableDebtToken.sol
@@ -25,7 +25,6 @@ contract VariableDebtToken is DebtTokenBase, IVariableDebtToken {
   using SafeCast for uint256;
 
   uint256 public constant DEBT_TOKEN_REVISION = 0x2;
-  address internal _underlyingAsset;
 
   /**
    * @dev Constructor.
@@ -173,11 +172,6 @@ contract VariableDebtToken is DebtTokenBase, IVariableDebtToken {
    * @return The address of the underlying asset
    **/
   function UNDERLYING_ASSET_ADDRESS() external view returns (address) {
-    return _underlyingAsset;
-  }
-
-  /// @inheritdoc DebtTokenBase
-  function _getUnderlyingAssetAddress() internal view override returns (address) {
     return _underlyingAsset;
   }
 }

--- a/contracts/protocol/tokenization/base/DebtTokenBase.sol
+++ b/contracts/protocol/tokenization/base/DebtTokenBase.sol
@@ -27,6 +27,8 @@ abstract contract DebtTokenBase is
 
   IPool public immutable POOL;
 
+  address internal _underlyingAsset;
+
   /**
    * @dev Only pool can call functions marked by this modifier.
    **/
@@ -98,13 +100,6 @@ abstract contract DebtTokenBase is
   }
 
   /**
-   * @notice Returns the address of the underlying asset of this debt token
-   * @dev For internal usage in the logic of the parent contracts
-   * @return The address of the underlying asset
-   **/
-  function _getUnderlyingAssetAddress() internal view virtual returns (address);
-
-  /**
    * @dev Being non transferrable, the debt token does not implement any of the
    * standard ERC20 functions for transfer and allowance.
    **/
@@ -148,7 +143,7 @@ abstract contract DebtTokenBase is
     uint256 amount
   ) internal {
     _borrowAllowances[delegator][delegatee] = amount;
-    emit BorrowAllowanceDelegated(delegator, delegatee, _getUnderlyingAssetAddress(), amount);
+    emit BorrowAllowanceDelegated(delegator, delegatee, _underlyingAsset, amount);
   }
 
   /**
@@ -166,6 +161,6 @@ abstract contract DebtTokenBase is
 
     _borrowAllowances[delegator][delegatee] = newAllowance;
 
-    emit BorrowAllowanceDelegated(delegator, delegatee, _getUnderlyingAssetAddress(), newAllowance);
+    emit BorrowAllowanceDelegated(delegator, delegatee, _underlyingAsset, newAllowance);
   }
 }


### PR DESCRIPTION
Closes #544 