### PR TITLE
fix: Remove SafeCast in Pool and use of uint256 for flashloan premiums

### DIFF
--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -631,8 +631,8 @@ interface IPool {
    * @param flashLoanPremiumToProtocol The part of the premium sent to the protocol treasury, expressed in bps
    */
   function updateFlashloanPremiums(
-    uint256 flashLoanPremiumTotal,
-    uint256 flashLoanPremiumToProtocol
+    uint128 flashLoanPremiumTotal,
+    uint128 flashLoanPremiumToProtocol
   ) external;
 
   /**
@@ -681,7 +681,7 @@ interface IPool {
    * @notice Returns the total fee on flash loans
    * @return The total fee on flashloans
    */
-  function FLASHLOAN_PREMIUM_TOTAL() external view returns (uint256);
+  function FLASHLOAN_PREMIUM_TOTAL() external view returns (uint128);
 
   /**
    * @notice Returns the part of the bridge fees sent to protocol
@@ -693,7 +693,7 @@ interface IPool {
    * @notice Returns the part of the flashloan fees sent to protocol
    * @return The flashloan fee sent to the protocol treasury
    */
-  function FLASHLOAN_PREMIUM_TO_PROTOCOL() external view returns (uint256);
+  function FLASHLOAN_PREMIUM_TO_PROTOCOL() external view returns (uint128);
 
   /**
    * @notice Returns the maximum number of reserves supported to be listed in this Pool

--- a/contracts/interfaces/IPoolConfigurator.sol
+++ b/contracts/interfaces/IPoolConfigurator.sol
@@ -223,8 +223,8 @@ interface IPoolConfigurator {
    * @param newFlashloanPremiumTotal The new premium, expressed in bps
    **/
   event FlashloanPremiumTotalUpdated(
-    uint256 oldFlashloanPremiumTotal,
-    uint256 newFlashloanPremiumTotal
+    uint128 oldFlashloanPremiumTotal,
+    uint128 newFlashloanPremiumTotal
   );
 
   /**
@@ -233,8 +233,8 @@ interface IPoolConfigurator {
    * @param newFlashloanPremiumToProtocol The new premium, expressed in bps
    **/
   event FlashloanPremiumToProtocolUpdated(
-    uint256 oldFlashloanPremiumToProtocol,
-    uint256 newFlashloanPremiumToProtocol
+    uint128 oldFlashloanPremiumToProtocol,
+    uint128 newFlashloanPremiumToProtocol
   );
 
   /**
@@ -432,7 +432,7 @@ interface IPoolConfigurator {
    * @dev The premium is calculated on the total amount borrowed
    * @param newFlashloanPremiumTotal The total flashloan premium
    */
-  function updateFlashloanPremiumTotal(uint256 newFlashloanPremiumTotal) external;
+  function updateFlashloanPremiumTotal(uint128 newFlashloanPremiumTotal) external;
 
   /**
    * @notice Updates the flash loan premium collected by protocol reserves
@@ -440,7 +440,7 @@ interface IPoolConfigurator {
    * @dev The premium to protocol is calculated on the total flashloan premium
    * @param newFlashloanPremiumToProtocol The part of the flashloan premium sent to the protocol treasury
    */
-  function updateFlashloanPremiumToProtocol(uint256 newFlashloanPremiumToProtocol) external;
+  function updateFlashloanPremiumToProtocol(uint128 newFlashloanPremiumToProtocol) external;
 
   /**
    * @notice Sets the debt ceiling for an asset.

--- a/contracts/protocol/pool/Pool.sol
+++ b/contracts/protocol/pool/Pool.sol
@@ -24,7 +24,6 @@ import {IAToken} from '../../interfaces/IAToken.sol';
 import {IPool} from '../../interfaces/IPool.sol';
 import {IACLManager} from '../../interfaces/IACLManager.sol';
 import {PoolStorage} from './PoolStorage.sol';
-import {SafeCast} from '../../dependencies/openzeppelin/contracts/SafeCast.sol';
 
 /**
  * @title Pool contract
@@ -45,7 +44,6 @@ import {SafeCast} from '../../dependencies/openzeppelin/contracts/SafeCast.sol';
  **/
 contract Pool is VersionedInitializable, IPool, PoolStorage {
   using WadRayMath for uint256;
-  using SafeCast for uint256;
   using GPv2SafeERC20 for IERC20;
   using ReserveLogic for DataTypes.ReserveData;
   using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
@@ -608,12 +606,12 @@ contract Pool is VersionedInitializable, IPool, PoolStorage {
   }
 
   /// @inheritdoc IPool
-  function FLASHLOAN_PREMIUM_TOTAL() public view override returns (uint256) {
+  function FLASHLOAN_PREMIUM_TOTAL() public view override returns (uint128) {
     return _flashLoanPremiumTotal;
   }
 
   /// @inheritdoc IPool
-  function FLASHLOAN_PREMIUM_TO_PROTOCOL() public view override returns (uint256) {
+  function FLASHLOAN_PREMIUM_TO_PROTOCOL() public view override returns (uint128) {
     return _flashLoanPremiumToProtocol;
   }
 
@@ -707,11 +705,11 @@ contract Pool is VersionedInitializable, IPool, PoolStorage {
 
   /// @inheritdoc IPool
   function updateFlashloanPremiums(
-    uint256 flashLoanPremiumTotal,
-    uint256 flashLoanPremiumToProtocol
+    uint128 flashLoanPremiumTotal,
+    uint128 flashLoanPremiumToProtocol
   ) external override onlyPoolConfigurator {
-    _flashLoanPremiumTotal = flashLoanPremiumTotal.toUint128();
-    _flashLoanPremiumToProtocol = flashLoanPremiumToProtocol.toUint128();
+    _flashLoanPremiumTotal = flashLoanPremiumTotal;
+    _flashLoanPremiumToProtocol = flashLoanPremiumToProtocol;
   }
 
   /// @inheritdoc IPool

--- a/contracts/protocol/pool/PoolConfigurator.sol
+++ b/contracts/protocol/pool/PoolConfigurator.sol
@@ -406,7 +406,7 @@ contract PoolConfigurator is VersionedInitializable, IPoolConfigurator {
   }
 
   /// @inheritdoc IPoolConfigurator
-  function updateFlashloanPremiumTotal(uint256 newFlashloanPremiumTotal)
+  function updateFlashloanPremiumTotal(uint128 newFlashloanPremiumTotal)
     external
     override
     onlyPoolAdmin
@@ -415,13 +415,13 @@ contract PoolConfigurator is VersionedInitializable, IPoolConfigurator {
       newFlashloanPremiumTotal <= PercentageMath.PERCENTAGE_FACTOR,
       Errors.FLASHLOAN_PREMIUM_INVALID
     );
-    uint256 oldFlashloanPremiumTotal = _pool.FLASHLOAN_PREMIUM_TOTAL();
+    uint128 oldFlashloanPremiumTotal = _pool.FLASHLOAN_PREMIUM_TOTAL();
     _pool.updateFlashloanPremiums(newFlashloanPremiumTotal, _pool.FLASHLOAN_PREMIUM_TO_PROTOCOL());
     emit FlashloanPremiumTotalUpdated(oldFlashloanPremiumTotal, newFlashloanPremiumTotal);
   }
 
   /// @inheritdoc IPoolConfigurator
-  function updateFlashloanPremiumToProtocol(uint256 newFlashloanPremiumToProtocol)
+  function updateFlashloanPremiumToProtocol(uint128 newFlashloanPremiumToProtocol)
     external
     override
     onlyPoolAdmin
@@ -430,7 +430,7 @@ contract PoolConfigurator is VersionedInitializable, IPoolConfigurator {
       newFlashloanPremiumToProtocol <= PercentageMath.PERCENTAGE_FACTOR,
       Errors.FLASHLOAN_PREMIUM_INVALID
     );
-    uint256 oldFlashloanPremiumToProtocol = _pool.FLASHLOAN_PREMIUM_TO_PROTOCOL();
+    uint128 oldFlashloanPremiumToProtocol = _pool.FLASHLOAN_PREMIUM_TO_PROTOCOL();
     _pool.updateFlashloanPremiums(_pool.FLASHLOAN_PREMIUM_TOTAL(), newFlashloanPremiumToProtocol);
     emit FlashloanPremiumToProtocolUpdated(
       oldFlashloanPremiumToProtocol,


### PR DESCRIPTION
Closes #590 

Gas and codesize comparison: https://www.diffchecker.com/OOgkbciL