### PR TITLE
fix: `reserves` renamed to `reservesData` or `reservesList` when fitting

### DIFF
--- a/contracts/protocol/libraries/configuration/UserConfiguration.sol
+++ b/contracts/protocol/libraries/configuration/UserConfiguration.sol
@@ -161,8 +161,8 @@ library UserConfiguration {
   /**
    * @notice Returns the Isolation Mode state of the user
    * @param self The configuration object
-   * @param reservesData The data of all the reserves
-   * @param reservesList The reserve list
+   * @param reservesData The state of all the reserves
+   * @param reservesList The addresses of all the active reserves
    * @return True if the user is in isolation mode, false otherwise
    * @return The address of the only asset used as collateral
    * @return The debt ceiling of the reserve

--- a/contracts/protocol/libraries/logic/BridgeLogic.sol
+++ b/contracts/protocol/libraries/logic/BridgeLogic.sol
@@ -40,8 +40,8 @@ library BridgeLogic {
    * @dev Essentially a supply without transferring the underlying.
    * @dev Emits the `MintUnbacked` event
    * @dev Emits the `ReserveUsedAsCollateralEnabled` if asset is set as collateral
-   * @param reserves The state of all the reserves
-   * @param reservesList The list of the addresses of all the active reserves
+   * @param reservesData The state of all the reserves
+   * @param reservesList The addresses of all the active reserves
    * @param userConfig The user configuration mapping that tracks the supplied/borrowed assets
    * @param asset The address of the underlying asset to mint aTokens of
    * @param amount The amount to mint
@@ -50,7 +50,7 @@ library BridgeLogic {
    *   0 if the action is executed directly by the user, without any middle-man
    **/
   function executeMintUnbacked(
-    mapping(address => DataTypes.ReserveData) storage reserves,
+    mapping(address => DataTypes.ReserveData) storage reservesData,
     mapping(uint256 => address) storage reservesList,
     DataTypes.UserConfigurationMap storage userConfig,
     address asset,
@@ -58,7 +58,7 @@ library BridgeLogic {
     address onBehalfOf,
     uint16 referralCode
   ) external {
-    DataTypes.ReserveData storage reserve = reserves[asset];
+    DataTypes.ReserveData storage reserve = reservesData[asset];
     DataTypes.ReserveCache memory reserveCache = reserve.cache();
 
     reserve.updateState(reserveCache);
@@ -82,7 +82,7 @@ library BridgeLogic {
     );
 
     if (isFirstSupply) {
-      if (ValidationLogic.validateUseAsCollateral(reserves, reservesList, userConfig, asset)) {
+      if (ValidationLogic.validateUseAsCollateral(reservesData, reservesList, userConfig, asset)) {
         userConfig.setUsingAsCollateral(reserve.id, true);
         emit ReserveUsedAsCollateralEnabled(asset, onBehalfOf);
       }

--- a/contracts/protocol/libraries/logic/EModeLogic.sol
+++ b/contracts/protocol/libraries/logic/EModeLogic.sol
@@ -32,15 +32,15 @@ library EModeLogic {
    * @notice Updates the user efficiency mode category
    * @dev Will revert if user is borrowing non-compatible asset or change will drop HF < HEALTH_FACTOR_LIQUIDATION_THRESHOLD
    * @dev Emits the `UserEModeSet` event
-   * @param reserves The state of all the reserves
-   * @param reservesList The list of the addresses of all the active reserves
+   * @param reservesData The state of all the reserves
+   * @param reservesList The addresses of all the active reserves
    * @param eModeCategories The configuration of all the efficiency mode categories
    * @param usersEModeCategory The state of all users efficiency mode category
    * @param userConfig The user configuration mapping that tracks the supplied/borrowed assets
    * @param params The additional parameters needed to execute the setUserEMode function
    */
   function executeSetUserEMode(
-    mapping(address => DataTypes.ReserveData) storage reserves,
+    mapping(address => DataTypes.ReserveData) storage reservesData,
     mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
     mapping(address => uint8) storage usersEModeCategory,
@@ -48,7 +48,7 @@ library EModeLogic {
     DataTypes.ExecuteSetUserEModeParams memory params
   ) external {
     ValidationLogic.validateSetUserEMode(
-      reserves,
+      reservesData,
       reservesList,
       eModeCategories,
       userConfig,
@@ -61,7 +61,7 @@ library EModeLogic {
 
     if (prevCategoryId != 0) {
       ValidationLogic.validateHealthFactor(
-        reserves,
+        reservesData,
         reservesList,
         eModeCategories,
         userConfig,

--- a/contracts/protocol/libraries/logic/GenericLogic.sol
+++ b/contracts/protocol/libraries/logic/GenericLogic.sol
@@ -50,8 +50,8 @@ library GenericLogic {
    * @notice Calculates the user data across the reserves.
    * @dev It includes the total liquidity/collateral/borrow balances in the base currency used by the price feed,
    * the average Loan To Value, the average Liquidation Ratio, and the Health factor.
-   * @param reservesData The data of all the reserves
-   * @param reserves The list of the available reserves
+   * @param reservesData The state of all the reserves
+   * @param reservesList The addresses of all the active reserves
    * @param eModeCategories The configuration of all the efficiency mode categories
    * @param params Additional parameters needed for the calculation
    * @return The total collateral of the user in the base currency used by the price feed
@@ -63,7 +63,7 @@ library GenericLogic {
    **/
   function calculateUserAccountData(
     mapping(address => DataTypes.ReserveData) storage reservesData,
-    mapping(uint256 => address) storage reserves,
+    mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
     DataTypes.CalculateUserAccountDataParams memory params
   )
@@ -100,7 +100,7 @@ library GenericLogic {
         continue;
       }
 
-      vars.currentReserveAddress = reserves[vars.i];
+      vars.currentReserveAddress = reservesList[vars.i];
 
       if (vars.currentReserveAddress == address(0)) {
         unchecked {

--- a/contracts/protocol/libraries/logic/IsolationModeLogic.sol
+++ b/contracts/protocol/libraries/logic/IsolationModeLogic.sol
@@ -21,24 +21,24 @@ library IsolationModeLogic {
 
   /**
    * @notice updated the isolated debt whenever a position collateralized by an isolated asset is repaid or liquidated
-   * @param reserves The state of all the reserves
+   * @param reservesData The state of all the reserves
    * @param reservesList The addresses of all the active reserves
    * @param userConfig The user configuration mapping
    * @param reserveCache The cached data of the reserve
    * @param repayAmount The amount being repaid
    */
   function updateIsolatedDebtIfIsolated(
-    mapping(address => DataTypes.ReserveData) storage reserves,
+    mapping(address => DataTypes.ReserveData) storage reservesData,
     mapping(uint256 => address) storage reservesList,
     DataTypes.UserConfigurationMap storage userConfig,
     DataTypes.ReserveCache memory reserveCache,
     uint256 repayAmount
   ) internal {
     (bool isolationModeActive, address isolationModeCollateralAddress, ) = userConfig
-      .getIsolationModeState(reserves, reservesList);
+      .getIsolationModeState(reservesData, reservesList);
 
     if (isolationModeActive) {
-      uint128 isolationModeTotalDebt = reserves[isolationModeCollateralAddress]
+      uint128 isolationModeTotalDebt = reservesData[isolationModeCollateralAddress]
         .isolationModeTotalDebt;
 
       uint128 isolatedDebtRepaid = (repayAmount /
@@ -49,10 +49,10 @@ library IsolationModeLogic {
       // since the debt ceiling does not take into account the interest accrued, it might happen that amount
       // repaid > debt in isolation mode
       if (isolationModeTotalDebt <= isolatedDebtRepaid) {
-        reserves[isolationModeCollateralAddress].isolationModeTotalDebt = 0;
+        reservesData[isolationModeCollateralAddress].isolationModeTotalDebt = 0;
         emit IsolationModeTotalDebtUpdated(isolationModeCollateralAddress, 0);
       } else {
-        uint256 nextIsolationModeTotalDebt = reserves[isolationModeCollateralAddress]
+        uint256 nextIsolationModeTotalDebt = reservesData[isolationModeCollateralAddress]
           .isolationModeTotalDebt = isolationModeTotalDebt - isolatedDebtRepaid;
         emit IsolationModeTotalDebtUpdated(
           isolationModeCollateralAddress,

--- a/contracts/protocol/libraries/logic/LiquidationLogic.sol
+++ b/contracts/protocol/libraries/logic/LiquidationLogic.sol
@@ -91,14 +91,14 @@ library LiquidationLogic {
    * covers `debtToCover` amount of debt of the user getting liquidated, and receives
    * a proportional amount of the `collateralAsset` plus a bonus to cover market risk
    * @dev Emits the `LiquidationCall()` event
-   * @param reserves The state of all the reserves
+   * @param reservesData The state of all the reserves
    * @param usersConfig The users configuration mapping that track the supplied/borrowed assets
    * @param reservesList The addresses of all the active reserves
    * @param eModeCategories The configuration of all the efficiency mode categories
    * @param params The additional parameters needed to execute the liquidation function
    **/
   function executeLiquidationCall(
-    mapping(address => DataTypes.ReserveData) storage reserves,
+    mapping(address => DataTypes.ReserveData) storage reservesData,
     mapping(address => DataTypes.UserConfigurationMap) storage usersConfig,
     mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
@@ -106,8 +106,8 @@ library LiquidationLogic {
   ) external {
     LiquidationCallLocalVars memory vars;
 
-    DataTypes.ReserveData storage collateralReserve = reserves[params.collateralAsset];
-    DataTypes.ReserveData storage debtReserve = reserves[params.debtAsset];
+    DataTypes.ReserveData storage collateralReserve = reservesData[params.collateralAsset];
+    DataTypes.ReserveData storage debtReserve = reservesData[params.debtAsset];
     DataTypes.UserConfigurationMap storage userConfig = usersConfig[params.user];
     vars.debtReserveCache = debtReserve.cache();
     debtReserve.updateState(vars.debtReserveCache);
@@ -120,7 +120,7 @@ library LiquidationLogic {
     vars.oracle = IPriceOracleGetter(params.priceOracle);
 
     (, , , , vars.healthFactor, ) = GenericLogic.calculateUserAccountData(
-      reserves,
+      reservesData,
       reservesList,
       eModeCategories,
       DataTypes.CalculateUserAccountDataParams({
@@ -221,7 +221,7 @@ library LiquidationLogic {
     );
 
     IsolationModeLogic.updateIsolatedDebtIfIsolated(
-      reserves,
+      reservesData,
       reservesList,
       userConfig,
       vars.debtReserveCache,
@@ -240,7 +240,7 @@ library LiquidationLogic {
         DataTypes.UserConfigurationMap storage liquidatorConfig = usersConfig[msg.sender];
         if (
           ValidationLogic.validateUseAsCollateral(
-            reserves,
+            reservesData,
             reservesList,
             liquidatorConfig,
             params.collateralAsset

--- a/contracts/protocol/libraries/logic/PoolLogic.sol
+++ b/contracts/protocol/libraries/logic/PoolLogic.sol
@@ -31,13 +31,13 @@ library PoolLogic {
   /**
    * @notice Initialize an asset reserve and add the reserve to the list of reserves
    * @param reservesData The state of all the reserves
-   * @param reserves The addresses of all the active reserves
+   * @param reservesList The addresses of all the active reserves
    * @param params Additional parameters needed for initiation
    * @return true if appended, false if inserted at existing empty spot
    **/
   function executeInitReserve(
     mapping(address => DataTypes.ReserveData) storage reservesData,
-    mapping(uint256 => address) storage reserves,
+    mapping(uint256 => address) storage reservesList,
     DataTypes.InitReserveParams memory params
   ) external returns (bool) {
     require(Address.isContract(params.asset), Errors.NOT_CONTRACT);
@@ -48,20 +48,21 @@ library PoolLogic {
       params.interestRateStrategyAddress
     );
 
-    bool reserveAlreadyAdded = reservesData[params.asset].id != 0 || reserves[0] == params.asset;
+    bool reserveAlreadyAdded = reservesData[params.asset].id != 0 ||
+      reservesList[0] == params.asset;
     require(!reserveAlreadyAdded, Errors.RESERVE_ALREADY_ADDED);
 
     for (uint16 i = 0; i < params.reservesCount; i++) {
-      if (reserves[i] == address(0)) {
+      if (reservesList[i] == address(0)) {
         reservesData[params.asset].id = i;
-        reserves[i] = params.asset;
+        reservesList[i] = params.asset;
         return false;
       }
     }
 
     require(params.reservesCount < params.maxNumberReserves, Errors.NO_MORE_RESERVES_ALLOWED);
     reservesData[params.asset].id = params.reservesCount;
-    reserves[params.reservesCount] = params.asset;
+    reservesList[params.reservesCount] = params.asset;
     return true;
   }
 
@@ -146,7 +147,7 @@ library PoolLogic {
   /**
    * @notice Returns the user account data across all the reserves
    * @param reservesData The state of all the reserves
-   * @param reserves The addresses of all the active reserves
+   * @param reservesList The addresses of all the active reserves
    * @param eModeCategories The configuration of all the efficiency mode categories
    * @param params Additional params needed for the calculation
    * @return totalCollateralBase The total collateral of the user in the base currency used by the price feed
@@ -158,7 +159,7 @@ library PoolLogic {
    **/
   function executeGetUserAccountData(
     mapping(address => DataTypes.ReserveData) storage reservesData,
-    mapping(uint256 => address) storage reserves,
+    mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
     DataTypes.CalculateUserAccountDataParams memory params
   )
@@ -180,7 +181,7 @@ library PoolLogic {
       currentLiquidationThreshold,
       healthFactor,
 
-    ) = GenericLogic.calculateUserAccountData(reservesData, reserves, eModeCategories, params);
+    ) = GenericLogic.calculateUserAccountData(reservesData, reservesList, eModeCategories, params);
 
     availableBorrowsBase = GenericLogic.calculateAvailableBorrows(
       totalCollateralBase,

--- a/contracts/protocol/libraries/logic/SupplyLogic.sol
+++ b/contracts/protocol/libraries/logic/SupplyLogic.sol
@@ -44,18 +44,18 @@ library SupplyLogic {
    * @dev Emits the `Supply()` event.
    * @dev In the first supply action, `ReserveUsedAsCollateralEnabled()` is emitted, if the asset can be enabled as
    * collateral.
-   * @param reserves The state of all the reserves
+   * @param reservesData The state of all the reserves
    * @param reservesList The addresses of all the active reserves
    * @param userConfig The user configuration mapping that tracks the supplied/borrowed assets
    * @param params The additional parameters needed to execute the supply function
    */
   function executeSupply(
-    mapping(address => DataTypes.ReserveData) storage reserves,
+    mapping(address => DataTypes.ReserveData) storage reservesData,
     mapping(uint256 => address) storage reservesList,
     DataTypes.UserConfigurationMap storage userConfig,
     DataTypes.ExecuteSupplyParams memory params
   ) external {
-    DataTypes.ReserveData storage reserve = reserves[params.asset];
+    DataTypes.ReserveData storage reserve = reservesData[params.asset];
     DataTypes.ReserveCache memory reserveCache = reserve.cache();
 
     reserve.updateState(reserveCache);
@@ -75,7 +75,12 @@ library SupplyLogic {
 
     if (isFirstSupply) {
       if (
-        ValidationLogic.validateUseAsCollateral(reserves, reservesList, userConfig, params.asset)
+        ValidationLogic.validateUseAsCollateral(
+          reservesData,
+          reservesList,
+          userConfig,
+          params.asset
+        )
       ) {
         userConfig.setUsingAsCollateral(reserve.id, true);
         emit ReserveUsedAsCollateralEnabled(params.asset, params.onBehalfOf);
@@ -90,7 +95,7 @@ library SupplyLogic {
    * previously supplied in the Aave protocol.
    * @dev Emits the `Withdraw()` event.
    * @dev If the user withdraws everything, `ReserveUsedAsCollateralDisabled()` is emitted.
-   * @param reserves The state of all the reserves
+   * @param reservesData The state of all the reserves
    * @param reservesList The addresses of all the active reserves
    * @param eModeCategories The configuration of all the efficiency mode categories
    * @param userConfig The user configuration mapping that tracks the supplied/borrowed assets
@@ -98,13 +103,13 @@ library SupplyLogic {
    * @return The actual amount withdrawn
    */
   function executeWithdraw(
-    mapping(address => DataTypes.ReserveData) storage reserves,
+    mapping(address => DataTypes.ReserveData) storage reservesData,
     mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
     DataTypes.UserConfigurationMap storage userConfig,
     DataTypes.ExecuteWithdrawParams memory params
   ) external returns (uint256) {
-    DataTypes.ReserveData storage reserve = reserves[params.asset];
+    DataTypes.ReserveData storage reserve = reservesData[params.asset];
     DataTypes.ReserveCache memory reserveCache = reserve.cache();
 
     reserve.updateState(reserveCache);
@@ -133,7 +138,7 @@ library SupplyLogic {
     if (userConfig.isUsingAsCollateral(reserve.id)) {
       if (userConfig.isBorrowingAny()) {
         ValidationLogic.validateHFAndLtv(
-          reserves,
+          reservesData,
           reservesList,
           eModeCategories,
           userConfig,
@@ -162,24 +167,24 @@ library SupplyLogic {
    * @dev Emits the `ReserveUsedAsCollateralEnabled()` event for the `to` account, if the asset is being activated as
    * collateral.
    * @dev In case the `from` user transfers everything, `ReserveUsedAsCollateralDisabled()` is emitted for `from`.
-   * @param reserves The state of all the reserves
+   * @param reservesData The state of all the reserves
    * @param reservesList The addresses of all the active reserves
    * @param eModeCategories The configuration of all the efficiency mode categories
    * @param usersConfig The users configuration mapping that track the supplied/borrowed assets
    * @param params The additional parameters needed to execute the finalizeTransfer function
    */
   function executeFinalizeTransfer(
-    mapping(address => DataTypes.ReserveData) storage reserves,
+    mapping(address => DataTypes.ReserveData) storage reservesData,
     mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
     mapping(address => DataTypes.UserConfigurationMap) storage usersConfig,
     DataTypes.FinalizeTransferParams memory params
   ) external {
-    DataTypes.ReserveData storage reserve = reserves[params.asset];
+    DataTypes.ReserveData storage reserve = reservesData[params.asset];
 
-    ValidationLogic.validateTransfer(reserves[params.asset]);
+    ValidationLogic.validateTransfer(reservesData[params.asset]);
 
-    uint256 reserveId = reserves[params.asset].id;
+    uint256 reserveId = reservesData[params.asset].id;
 
     if (params.from != params.to && params.amount != 0) {
       DataTypes.UserConfigurationMap storage fromConfig = usersConfig[params.from];
@@ -187,7 +192,7 @@ library SupplyLogic {
       if (fromConfig.isUsingAsCollateral(reserveId)) {
         if (fromConfig.isBorrowingAny()) {
           ValidationLogic.validateHFAndLtv(
-            reserves,
+            reservesData,
             reservesList,
             eModeCategories,
             usersConfig[params.from],
@@ -207,7 +212,12 @@ library SupplyLogic {
       if (params.balanceToBefore == 0) {
         DataTypes.UserConfigurationMap storage toConfig = usersConfig[params.to];
         if (
-          ValidationLogic.validateUseAsCollateral(reserves, reservesList, toConfig, params.asset)
+          ValidationLogic.validateUseAsCollateral(
+            reservesData,
+            reservesList,
+            toConfig,
+            params.asset
+          )
         ) {
           toConfig.setUsingAsCollateral(reserve.id, true);
           emit ReserveUsedAsCollateralEnabled(params.asset, params.to);
@@ -222,7 +232,7 @@ library SupplyLogic {
    * checks to ensure collateralization.
    * @dev Emits the `ReserveUsedAsCollateralEnabled()` event if the asset can be activated as collateral.
    * @dev In case the asset is being deactivated as collateral, `ReserveUsedAsCollateralDisabled()` is emitted.
-   * @param reserves The state of all the reserves
+   * @param reservesData The state of all the reserves
    * @param reservesList The addresses of all the active reserves
    * @param eModeCategories The configuration of all the efficiency mode categories
    * @param userConfig The users configuration mapping that track the supplied/borrowed assets
@@ -233,7 +243,7 @@ library SupplyLogic {
    * @param userEModeCategory The eMode category chosen by the user
    */
   function executeUseReserveAsCollateral(
-    mapping(address => DataTypes.ReserveData) storage reserves,
+    mapping(address => DataTypes.ReserveData) storage reservesData,
     mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
     DataTypes.UserConfigurationMap storage userConfig,
@@ -243,7 +253,7 @@ library SupplyLogic {
     address priceOracle,
     uint8 userEModeCategory
   ) external {
-    DataTypes.ReserveData storage reserve = reserves[asset];
+    DataTypes.ReserveData storage reserve = reservesData[asset];
     DataTypes.ReserveCache memory reserveCache = reserve.cache();
 
     uint256 userBalance = IERC20(reserveCache.aTokenAddress).balanceOf(msg.sender);
@@ -254,7 +264,7 @@ library SupplyLogic {
 
     if (useAsCollateral) {
       require(
-        ValidationLogic.validateUseAsCollateral(reserves, reservesList, userConfig, asset),
+        ValidationLogic.validateUseAsCollateral(reservesData, reservesList, userConfig, asset),
         Errors.USER_IN_ISOLATION_MODE
       );
 
@@ -263,7 +273,7 @@ library SupplyLogic {
     } else {
       userConfig.setUsingAsCollateral(reserve.id, false);
       ValidationLogic.validateHFAndLtv(
-        reserves,
+        reservesData,
         reservesList,
         eModeCategories,
         userConfig,

--- a/contracts/protocol/libraries/logic/ValidationLogic.sol
+++ b/contracts/protocol/libraries/logic/ValidationLogic.sol
@@ -133,13 +133,13 @@ library ValidationLogic {
   /**
    * @notice Validates a borrow action.
    * @param reservesData The state of all the reserves
-   * @param reserves The addresses of all the active reserves
+   * @param reservesList The addresses of all the active reserves
    * @param eModeCategories The configuration of all the efficiency mode categories
    * @param params Additional params needed for the validation
    */
   function validateBorrow(
     mapping(address => DataTypes.ReserveData) storage reservesData,
-    mapping(uint256 => address) storage reserves,
+    mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
     DataTypes.ValidateBorrowParams memory params
   ) internal view {
@@ -228,7 +228,7 @@ library ValidationLogic {
 
     ) = GenericLogic.calculateUserAccountData(
       reservesData,
-      reserves,
+      reservesList,
       eModeCategories,
       DataTypes.CalculateUserAccountDataParams({
         userConfig: params.userConfig,
@@ -537,7 +537,7 @@ library ValidationLogic {
   /**
    * @notice Validates the health factor of a user.
    * @param reservesData The state of all the reserves
-   * @param reserves The addresses of all the active reserves
+   * @param reservesList The addresses of all the active reserves
    * @param eModeCategories The configuration of all the efficiency mode categories
    * @param userConfig The state of the user for the specific reserve
    * @param user The user to validate health factor of
@@ -547,7 +547,7 @@ library ValidationLogic {
    */
   function validateHealthFactor(
     mapping(address => DataTypes.ReserveData) storage reservesData,
-    mapping(uint256 => address) storage reserves,
+    mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
     DataTypes.UserConfigurationMap memory userConfig,
     address user,
@@ -558,7 +558,7 @@ library ValidationLogic {
     (, , , , uint256 healthFactor, bool hasZeroLtvCollateral) = GenericLogic
       .calculateUserAccountData(
         reservesData,
-        reserves,
+        reservesList,
         eModeCategories,
         DataTypes.CalculateUserAccountDataParams({
           userConfig: userConfig,
@@ -580,7 +580,7 @@ library ValidationLogic {
   /**
    * @notice Validates the health factor of a user and the ltv of the asset being withdrawn.
    * @param reservesData The state of all the reserves
-   * @param reserves The addresses of all the active reserves
+   * @param reservesList The addresses of all the active reserves
    * @param eModeCategories The configuration of all the efficiency mode categories
    * @param userConfig The state of the user for the specific reserve
    * @param asset The asset for which the ltv will be validated
@@ -591,7 +591,7 @@ library ValidationLogic {
    */
   function validateHFAndLtv(
     mapping(address => DataTypes.ReserveData) storage reservesData,
-    mapping(uint256 => address) storage reserves,
+    mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
     DataTypes.UserConfigurationMap memory userConfig,
     address asset,
@@ -604,7 +604,7 @@ library ValidationLogic {
 
     (, bool hasZeroLtvCollateral) = validateHealthFactor(
       reservesData,
-      reserves,
+      reservesList,
       eModeCategories,
       userConfig,
       from,
@@ -629,17 +629,17 @@ library ValidationLogic {
 
   /**
    * @notice Validates a drop reserve action.
-   * @param reserves a mapping storing the list of reserves
+   * @param reservesList The addresses of all the active reserves
    * @param reserve The reserve object
    * @param asset The address of the reserve's underlying asset
    **/
   function validateDropReserve(
-    mapping(uint256 => address) storage reserves,
+    mapping(uint256 => address) storage reservesList,
     DataTypes.ReserveData storage reserve,
     address asset
   ) internal view {
     require(asset != address(0), Errors.ZERO_ADDRESS_NOT_VALID);
-    require(reserve.id != 0 || reserves[0] == asset, Errors.ASSET_NOT_LISTED);
+    require(reserve.id != 0 || reservesList[0] == asset, Errors.ASSET_NOT_LISTED);
     require(IERC20(reserve.stableDebtTokenAddress).totalSupply() == 0, Errors.STABLE_DEBT_NOT_ZERO);
     require(
       IERC20(reserve.variableDebtTokenAddress).totalSupply() == 0,
@@ -650,8 +650,8 @@ library ValidationLogic {
 
   /**
    * @notice Validates the action of setting efficiency mode.
-   * @param reservesData the data mapping of the reserves
-   * @param reserves a mapping storing the list of reserves
+   * @param reservesData The state of all the reserves
+   * @param reservesList The addresses of all the active reserves
    * @param eModeCategories a mapping storing configurations for all efficiency mode categories
    * @param userConfig the user configuration
    * @param reservesCount The total number of valid reserves
@@ -659,7 +659,7 @@ library ValidationLogic {
    **/
   function validateSetUserEMode(
     mapping(address => DataTypes.ReserveData) storage reservesData,
-    mapping(uint256 => address) storage reserves,
+    mapping(uint256 => address) storage reservesList,
     mapping(uint8 => DataTypes.EModeCategory) storage eModeCategories,
     DataTypes.UserConfigurationMap memory userConfig,
     uint256 reservesCount,
@@ -682,7 +682,7 @@ library ValidationLogic {
       unchecked {
         for (uint256 i = 0; i < reservesCount; i++) {
           if (userConfig.isBorrowing(i)) {
-            DataTypes.ReserveConfigurationMap memory configuration = reservesData[reserves[i]]
+            DataTypes.ReserveConfigurationMap memory configuration = reservesData[reservesList[i]]
               .configuration;
             require(
               configuration.getEModeCategory() == categoryId,
@@ -699,15 +699,15 @@ library ValidationLogic {
    * set as collateral, mint unbacked, and liquidate
    * @dev This is used to ensure that the constraints for isolated assets are respected by all the actions that
    * generate transfers of aTokens
-   * @param reservesData the data mapping of the reserves
-   * @param reserves a mapping storing the list of reserves
+   * @param reservesData The state of all the reserves
+   * @param reservesList The addresses of all the active reserves
    * @param userConfig the user configuration
    * @param asset The address of the asset being validated as collateral
    * @return True if the asset can be activated as collateral, false otherwise
    **/
   function validateUseAsCollateral(
     mapping(address => DataTypes.ReserveData) storage reservesData,
-    mapping(uint256 => address) storage reserves,
+    mapping(uint256 => address) storage reservesList,
     DataTypes.UserConfigurationMap storage userConfig,
     address asset
   ) internal view returns (bool) {
@@ -715,7 +715,7 @@ library ValidationLogic {
       return true;
     }
 
-    (bool isolationModeActive, , ) = userConfig.getIsolationModeState(reservesData, reserves);
+    (bool isolationModeActive, , ) = userConfig.getIsolationModeState(reservesData, reservesList);
     DataTypes.ReserveConfigurationMap memory configuration = reservesData[asset].configuration;
 
     return (!isolationModeActive && configuration.getDebtCeiling() == 0);


### PR DESCRIPTION
Closes #634 