### PR TITLE
misc: Bump deploy-v3 library to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "tmp-promise": "^3.0.2"
       },
       "devDependencies": {
-        "@aave/deploy-v3": "^1.17.0",
-        "@aave/periphery-v3": "^1.10.0",
+        "@aave/deploy-v3": "^1.21.0",
+        "@aave/periphery-v3": "^1.13.0",
         "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
         "@tenderly/hardhat-tenderly": "^1.1.0-beta.5",
         "@typechain/ethers-v5": "^7.2.0",
@@ -57,11 +57,11 @@
       }
     },
     "node_modules/@aave/core-v3": {
-      "version": "1.11.0",
-      "resolved": "https://npm.pkg.github.com/download/@aave/core-v3/1.11.0/464d37078d87c072de54ed5bab50c8fdad26f9901fbf6fc999c0427bf8d70041",
-      "integrity": "sha512-cesTe5okYtkfieuuIV077eL7eFQzteqX8rgfyi/W5PF4Us4aJ5rPyzqPGaNJmYCWMakw/Z90YDcGIe2T+o5Dqg==",
+      "version": "1.14.2",
+      "resolved": "https://npm.pkg.github.com/download/@aave/core-v3/1.14.2/4f9d7f392d3801f1e30a8336d2eaba73a38c43f60f096871880683abccbbeac2",
+      "integrity": "sha512-3nq/WHuKpVU15yT3vemSx2gr8wzQuuzBjSailnnXbA4fMzHavZQLBTE0eLIbNFPkGAwx+jnECYZ2TuSnEqzMHQ==",
       "dev": true,
-      "license": "AGPLv3",
+      "license": "BUSL-1.1",
       "dependencies": {
         "@nomiclabs/hardhat-etherscan": "^2.1.7",
         "axios-curlirize": "^1.3.7",
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@aave/deploy-v3": {
-      "version": "1.17.0",
-      "resolved": "https://npm.pkg.github.com/download/@aave/deploy-v3/1.17.0/ba685379a0cfabf76a2a25b97af17d7958a666fc0803f694dae471e4c976d182",
-      "integrity": "sha512-OH15Y3EEapVeuqilD6aIW7gqiBUxj6LxL4PI5MmtXgR7nZiJBSZJg9ud4KjXarwuObh11jgAsC4jtcKE4lDYpA==",
+      "version": "1.21.0",
+      "resolved": "https://npm.pkg.github.com/download/@aave/deploy-v3/1.21.0/4b217d01e22b1bc93ae8beadea2af41ac1755593e05202e47cb771822af9eef3",
+      "integrity": "sha512-huzp1a3vNBAxHPbG8Y/qZDJIFKO/ob4PgLt9pNcEa5uHfTZAbN40p5bYGyBty2+I/F1Np7vtH9dtSUC/zrmfHw==",
       "dev": true,
       "license": "AGPLv3",
       "dependencies": {
@@ -84,13 +84,13 @@
       }
     },
     "node_modules/@aave/periphery-v3": {
-      "version": "1.10.0",
-      "resolved": "https://npm.pkg.github.com/download/@aave/periphery-v3/1.10.0/59c7f06d0b3e3830a152cc535eeb6392bf878cdd4f1a4d03d3240bad43a83224",
-      "integrity": "sha512-Bjyw13WpwK5Q0W2FfiUG+3UPuX9Y4m9UgrlfSidGnoNjW0TON8MK0d4eauQeo5s4ZDI+pHlPClLucSng4K6fwg==",
+      "version": "1.13.0",
+      "resolved": "https://npm.pkg.github.com/download/@aave/periphery-v3/1.13.0/e41c12c041f6a78d40c876c7eaa251232ba57fc530adf22d9f39e38875f06708",
+      "integrity": "sha512-cxww6//tyj2IH20OYorkOUTIYVtFrZ0vuAacBflbNpJ5BTWhHdP47PoCqlMerS7Ll6UraTchyl5W4Tf9EClwaQ==",
       "dev": true,
       "license": "AGPLv3",
       "dependencies": {
-        "@aave/core-v3": "^1.10.0"
+        "@aave/core-v3": "^1.14.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -24417,9 +24417,9 @@
   },
   "dependencies": {
     "@aave/core-v3": {
-      "version": "1.11.0",
-      "resolved": "https://npm.pkg.github.com/download/@aave/core-v3/1.11.0/464d37078d87c072de54ed5bab50c8fdad26f9901fbf6fc999c0427bf8d70041",
-      "integrity": "sha512-cesTe5okYtkfieuuIV077eL7eFQzteqX8rgfyi/W5PF4Us4aJ5rPyzqPGaNJmYCWMakw/Z90YDcGIe2T+o5Dqg==",
+      "version": "1.14.2",
+      "resolved": "https://npm.pkg.github.com/download/@aave/core-v3/1.14.2/4f9d7f392d3801f1e30a8336d2eaba73a38c43f60f096871880683abccbbeac2",
+      "integrity": "sha512-3nq/WHuKpVU15yT3vemSx2gr8wzQuuzBjSailnnXbA4fMzHavZQLBTE0eLIbNFPkGAwx+jnECYZ2TuSnEqzMHQ==",
       "dev": true,
       "requires": {
         "@nomiclabs/hardhat-etherscan": "^2.1.7",
@@ -24428,21 +24428,21 @@
       }
     },
     "@aave/deploy-v3": {
-      "version": "1.17.0",
-      "resolved": "https://npm.pkg.github.com/download/@aave/deploy-v3/1.17.0/ba685379a0cfabf76a2a25b97af17d7958a666fc0803f694dae471e4c976d182",
-      "integrity": "sha512-OH15Y3EEapVeuqilD6aIW7gqiBUxj6LxL4PI5MmtXgR7nZiJBSZJg9ud4KjXarwuObh11jgAsC4jtcKE4lDYpA==",
+      "version": "1.21.0",
+      "resolved": "https://npm.pkg.github.com/download/@aave/deploy-v3/1.21.0/4b217d01e22b1bc93ae8beadea2af41ac1755593e05202e47cb771822af9eef3",
+      "integrity": "sha512-huzp1a3vNBAxHPbG8Y/qZDJIFKO/ob4PgLt9pNcEa5uHfTZAbN40p5bYGyBty2+I/F1Np7vtH9dtSUC/zrmfHw==",
       "dev": true,
       "requires": {
         "defender-relay-client": "^1.11.1"
       }
     },
     "@aave/periphery-v3": {
-      "version": "1.10.0",
-      "resolved": "https://npm.pkg.github.com/download/@aave/periphery-v3/1.10.0/59c7f06d0b3e3830a152cc535eeb6392bf878cdd4f1a4d03d3240bad43a83224",
-      "integrity": "sha512-Bjyw13WpwK5Q0W2FfiUG+3UPuX9Y4m9UgrlfSidGnoNjW0TON8MK0d4eauQeo5s4ZDI+pHlPClLucSng4K6fwg==",
+      "version": "1.13.0",
+      "resolved": "https://npm.pkg.github.com/download/@aave/periphery-v3/1.13.0/e41c12c041f6a78d40c876c7eaa251232ba57fc530adf22d9f39e38875f06708",
+      "integrity": "sha512-cxww6//tyj2IH20OYorkOUTIYVtFrZ0vuAacBflbNpJ5BTWhHdP47PoCqlMerS7Ll6UraTchyl5W4Tf9EClwaQ==",
       "dev": true,
       "requires": {
-        "@aave/core-v3": "^1.10.0"
+        "@aave/core-v3": "^1.14.2"
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "prepublish": "npm run compile"
   },
   "devDependencies": {
-    "@aave/deploy-v3": "^1.17.0",
-    "@aave/periphery-v3": "^1.10.0",
+    "@aave/deploy-v3": "^1.21.0",
+    "@aave/periphery-v3": "^1.13.0",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
     "@tenderly/hardhat-tenderly": "^1.1.0-beta.5",
     "@typechain/ethers-v5": "^7.2.0",

--- a/setup-test-env.sh
+++ b/setup-test-env.sh
@@ -38,5 +38,5 @@ cp -r node_modules/@aave/deploy-v3/artifacts/contracts/* temp-artifacts/deploy
 
 # Export MARKET_NAME variable to use Aave market as testnet deployment setup
 export MARKET_NAME="Test"
-
+export ENABLE_REWARDS="false"
 echo "[BASH] Testnet enviroment ready"


### PR DESCRIPTION
- Bump deploy-v3 dependency to latest version|
- Bump periphery-v3 dependency to latest version
- Explicitly disable rewards setup for tests