### PR TITLE
fix: add comment for undocumentted parameter

### DIFF
--- a/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol
+++ b/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol
@@ -95,6 +95,7 @@ abstract contract ScaledBalanceTokenBase is MintableIncentivizedERC20, IScaledBa
    * @dev In some instances, a burn transaction will emit a mint event
    * if the amount to burn is less than the interest that the user accrued
    * @param user The user which debt is burnt
+   * @param target The address that will receive the underlying, if any
    * @param amount The amount getting burned
    * @param index The variable debt index of the reserve
    **/


### PR DESCRIPTION
Adding a comment for the target param in the `_burnScaled` function