### PR TITLE
Optimisation of the balance/debt increase math

### DIFF
--- a/contracts/protocol/libraries/logic/ReserveLogic.sol
+++ b/contracts/protocol/libraries/logic/ReserveLogic.sol
@@ -211,15 +211,6 @@ library ReserveLogic {
     );
   }
 
-  struct AccrueToTreasuryLocalVars {
-    uint256 prevTotalStableDebt;
-    uint256 prevTotalVariableDebt;
-    uint256 currTotalVariableDebt;
-    uint256 cumulatedStableInterest;
-    uint256 totalDebtAccrued;
-    uint256 amountToMint;
-  }
-
   /**
    * @notice Mints part of the repaid interest to the reserve treasury as a function of the reserve factor for the
    * specific asset.
@@ -230,47 +221,35 @@ library ReserveLogic {
     DataTypes.ReserveData storage reserve,
     DataTypes.ReserveCache memory reserveCache
   ) internal {
-    AccrueToTreasuryLocalVars memory vars;
-
     if (reserveCache.reserveFactor == 0) {
       return;
     }
 
-    //calculate the total variable debt at moment of the last interaction
-    vars.prevTotalVariableDebt = reserveCache.currScaledVariableDebt.rayMul(
-      reserveCache.currVariableBorrowIndex
-    );
-
-    //calculate the new total variable debt after accumulation of the interest on the index
-    vars.currTotalVariableDebt = reserveCache.currScaledVariableDebt.rayMul(
-      reserveCache.nextVariableBorrowIndex
+    // calculate the total variable debt increase after the moment of the last interaction
+    uint256 variableDebtIncrease = reserveCache.currScaledVariableDebt.rayMul(
+      reserveCache.nextVariableBorrowIndex - reserveCache.currVariableBorrowIndex
     );
 
     //calculate the stable debt until the last timestamp update
-    vars.cumulatedStableInterest = MathUtils.calculateCompoundedInterest(
+    uint256 cumulatedStableInterest = MathUtils.calculateCompoundedInterest(
       reserveCache.currAvgStableBorrowRate,
       reserveCache.stableDebtLastUpdateTimestamp,
       reserveCache.reserveLastUpdateTimestamp
     );
 
-    vars.prevTotalStableDebt = reserveCache.currPrincipalStableDebt.rayMul(
-      vars.cumulatedStableInterest
+    uint256 prevTotalStableDebt = reserveCache.currPrincipalStableDebt.rayMul(
+      cumulatedStableInterest
     );
 
     //debt accrued is the sum of the current debt minus the sum of the debt at the last update
-    vars.totalDebtAccrued =
-      vars.currTotalVariableDebt +
+    uint256 totalDebtAccrued = variableDebtIncrease +
       reserveCache.currTotalStableDebt -
-      vars.prevTotalVariableDebt -
-      vars.prevTotalStableDebt;
+      prevTotalStableDebt;
 
-    vars.amountToMint = vars.totalDebtAccrued.percentMul(reserveCache.reserveFactor);
+    uint256 amountToMint = totalDebtAccrued.percentMul(reserveCache.reserveFactor);
 
-    if (vars.amountToMint != 0) {
-      reserve.accruedToTreasury += vars
-        .amountToMint
-        .rayDiv(reserveCache.nextLiquidityIndex)
-        .toUint128();
+    if (amountToMint != 0) {
+      reserve.accruedToTreasury += amountToMint.rayDiv(reserveCache.nextLiquidityIndex).toUint128();
     }
   }
 

--- a/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol
+++ b/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol
@@ -76,9 +76,7 @@ abstract contract ScaledBalanceTokenBase is MintableIncentivizedERC20, IScaledBa
     require(amountScaled != 0, Errors.INVALID_MINT_AMOUNT);
 
     uint256 scaledBalance = super.balanceOf(onBehalfOf);
-    uint256 balanceIncrease = scaledBalance.rayMul(index) -
-      scaledBalance.rayMul(_userState[onBehalfOf].additionalData);
-
+    uint256 balanceIncrease = scaledBalance.rayMul(index - _userState[onBehalfOf].additionalData);
     _userState[onBehalfOf].additionalData = index.toUint128();
 
     _mint(onBehalfOf, amountScaled.toUint128());
@@ -109,8 +107,7 @@ abstract contract ScaledBalanceTokenBase is MintableIncentivizedERC20, IScaledBa
     require(amountScaled != 0, Errors.INVALID_BURN_AMOUNT);
 
     uint256 scaledBalance = super.balanceOf(user);
-    uint256 balanceIncrease = scaledBalance.rayMul(index) -
-      scaledBalance.rayMul(_userState[user].additionalData);
+    uint256 balanceIncrease = scaledBalance.rayMul(index - _userState[user].additionalData);
 
     _userState[user].additionalData = index.toUint128();
 


### PR DESCRIPTION
This PR removes one operation in the balance/debt increase-related calculations. Also because of this opt it's no need to use `AccrueToTreasuryLocalVars` on the `_accrueToTreasury` function