### PR TITLE
Make mintToTreasury virtual so it can be overridden

### DIFF
--- a/contracts/protocol/tokenization/AToken.sol
+++ b/contracts/protocol/tokenization/AToken.sol
@@ -107,7 +107,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
   }
 
   /// @inheritdoc IAToken
-  function mintToTreasury(uint256 amount, uint256 index) external override onlyPool {
+  function mintToTreasury(uint256 amount, uint256 index) external virtual override onlyPool {
     if (amount == 0) {
       return;
     }


### PR DESCRIPTION
This PR makes AToken's `mintToTreasury` function overridable.

Having this function be virtual will make `AToken` easier to extend, e.g. for [grant-funded projects](https://twitter.com/AaveGrants/status/1586858440080572417) like [the one I'm working on](https://hackmd.io/@scopelift/Syg2nuNMo). It would also be consistent with the treatment of similar functions like AToken's `mint`, which is virtual:

https://github.com/aave/aave-v3-core/blob/f3e037b3638e3b7c98f0c09c56c5efde54f7c5d2/contracts/protocol/tokenization/AToken.sol#L87-L92

