### PR TITLE
Fixes #730. accruedToTreasury not being properly considered together with aToken supply

### DIFF
--- a/contracts/protocol/libraries/helpers/Errors.sol
+++ b/contracts/protocol/libraries/helpers/Errors.sol
@@ -60,7 +60,7 @@ library Errors {
   string public constant SUPPLY_CAP_EXCEEDED = '51'; // 'Supply cap is exceeded'
   string public constant UNBACKED_MINT_CAP_EXCEEDED = '52'; // 'Unbacked mint cap is exceeded'
   string public constant DEBT_CEILING_EXCEEDED = '53'; // 'Debt ceiling is exceeded'
-  string public constant ATOKEN_SUPPLY_NOT_ZERO = '54'; // 'AToken supply is not zero'
+  string public constant UNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO = '54'; // 'Claimable rights over underlying not zero (aToken supply or accruedToTreasury)'
   string public constant STABLE_DEBT_NOT_ZERO = '55'; // 'Stable debt supply is not zero'
   string public constant VARIABLE_DEBT_SUPPLY_NOT_ZERO = '56'; // 'Variable debt supply is not zero'
   string public constant LTV_VALIDATION_FAILED = '57'; // 'Ltv validation failed'

--- a/contracts/protocol/libraries/logic/BridgeLogic.sol
+++ b/contracts/protocol/libraries/logic/BridgeLogic.sol
@@ -63,7 +63,7 @@ library BridgeLogic {
 
     reserve.updateState(reserveCache);
 
-    ValidationLogic.validateSupply(reserveCache, amount);
+    ValidationLogic.validateSupply(reserveCache, reserve, amount);
 
     uint256 unbackedMintCap = reserveCache.reserveConfiguration.getUnbackedMintCap();
     uint256 reserveDecimals = reserveCache.reserveConfiguration.getDecimals();
@@ -125,7 +125,8 @@ library BridgeLogic {
     uint256 added = backingAmount + fee;
 
     reserveCache.nextLiquidityIndex = reserve.cumulateToLiquidityIndex(
-      IERC20(reserveCache.aTokenAddress).totalSupply(),
+      IERC20(reserveCache.aTokenAddress).totalSupply() +
+        uint256(reserve.accruedToTreasury).rayMul(reserveCache.nextLiquidityIndex),
       feeToLP
     );
 

--- a/contracts/protocol/libraries/logic/FlashLoanLogic.sol
+++ b/contracts/protocol/libraries/logic/FlashLoanLogic.sol
@@ -231,7 +231,8 @@ library FlashLoanLogic {
     DataTypes.ReserveCache memory reserveCache = reserve.cache();
     reserve.updateState(reserveCache);
     reserveCache.nextLiquidityIndex = reserve.cumulateToLiquidityIndex(
-      IERC20(reserveCache.aTokenAddress).totalSupply(),
+      IERC20(reserveCache.aTokenAddress).totalSupply() +
+        uint256(reserve.accruedToTreasury).rayMul(reserveCache.nextLiquidityIndex),
       premiumToLP
     );
 

--- a/contracts/protocol/libraries/logic/SupplyLogic.sol
+++ b/contracts/protocol/libraries/logic/SupplyLogic.sol
@@ -60,7 +60,7 @@ library SupplyLogic {
 
     reserve.updateState(reserveCache);
 
-    ValidationLogic.validateSupply(reserveCache, params.amount);
+    ValidationLogic.validateSupply(reserveCache, reserve, params.amount);
 
     reserve.updateInterestRates(reserveCache, params.asset, params.amount, 0);
 
@@ -264,7 +264,12 @@ library SupplyLogic {
 
     if (useAsCollateral) {
       require(
-        ValidationLogic.validateUseAsCollateral(reservesData, reservesList, userConfig, reserveCache.reserveConfiguration),
+        ValidationLogic.validateUseAsCollateral(
+          reservesData,
+          reservesList,
+          userConfig,
+          reserveCache.reserveConfiguration
+        ),
         Errors.USER_IN_ISOLATION_MODE
       );
 

--- a/contracts/protocol/libraries/logic/ValidationLogic.sol
+++ b/contracts/protocol/libraries/logic/ValidationLogic.sol
@@ -71,11 +71,8 @@ library ValidationLogic {
     uint256 supplyCap = reserveCache.reserveConfiguration.getSupplyCap();
     require(
       supplyCap == 0 ||
-        (IAToken(reserveCache.aTokenAddress).scaledTotalSupply().rayMul(
-          reserveCache.nextLiquidityIndex
-        ) +
-          uint256(reserve.accruedToTreasury).rayMul(reserveCache.nextLiquidityIndex) +
-          amount) <=
+        ((IAToken(reserveCache.aTokenAddress).scaledTotalSupply() +
+          uint256(reserve.accruedToTreasury)).rayMul(reserveCache.nextLiquidityIndex) + amount) <=
         supplyCap * (10**reserveCache.reserveConfiguration.getDecimals()),
       Errors.SUPPLY_CAP_EXCEEDED
     );
@@ -655,7 +652,7 @@ library ValidationLogic {
     );
     require(
       IERC20(reserve.aTokenAddress).totalSupply() == 0 && reserve.accruedToTreasury == 0,
-      Errors.ATOKEN_SUPPLY_NOT_ZERO
+      Errors.UNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO
     );
   }
 

--- a/contracts/protocol/pool/PoolConfigurator.sol
+++ b/contracts/protocol/pool/PoolConfigurator.sol
@@ -480,9 +480,11 @@ contract PoolConfigurator is VersionedInitializable, IPoolConfigurator {
   }
 
   function _checkNoSuppliers(address asset) internal view {
-    uint256 totalATokens = IPoolDataProvider(_addressesProvider.getPoolDataProvider())
-      .getATokenTotalSupply(asset);
-    require(totalATokens == 0, Errors.RESERVE_LIQUIDITY_NOT_ZERO);
+    (, uint256 accruedToTreasury, uint256 totalATokens, , , , , , , , , ) = IPoolDataProvider(
+      _addressesProvider.getPoolDataProvider()
+    ).getReserveData(asset);
+
+    require(totalATokens == 0 && accruedToTreasury == 0, Errors.RESERVE_LIQUIDITY_NOT_ZERO);
   }
 
   function _checkNoBorrowers(address asset) internal view {

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -124,7 +124,7 @@ export enum ProtocolErrors {
   SUPPLY_CAP_EXCEEDED = '51', // 'Supply cap is exceeded'
   UNBACKED_MINT_CAP_EXCEEDED = '52', // 'Unbacked mint cap is exceeded'
   DEBT_CEILING_EXCEEDED = '53', // 'Debt ceiling is exceeded'
-  ATOKEN_SUPPLY_NOT_ZERO = '54', // 'AToken supply is not zero'
+  UNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO = '54', // 'AToken supply is not zero'
   STABLE_DEBT_NOT_ZERO = '55', // 'Stable debt supply is not zero'
   VARIABLE_DEBT_SUPPLY_NOT_ZERO = '56', // 'Variable debt supply is not zero'
   LTV_VALIDATION_FAILED = '57', // 'Ltv validation failed'

--- a/test-suites/helpers/utils/calculations.ts
+++ b/test-suites/helpers/utils/calculations.ts
@@ -269,7 +269,9 @@ export const calcExpectedReserveDataAfterBackUnbacked = (
 
   expectedReserveData.liquidityIndex = cumulateToLiquidityIndex(
     expectedReserveData.liquidityIndex,
-    totalSupply,
+    totalSupply.add(
+      expectedReserveData.accruedToTreasuryScaled.rayMul(expectedReserveData.liquidityIndex)
+    ),
     premiumToLP
   );
 

--- a/test-suites/liquidity-indexes.spec.ts
+++ b/test-suites/liquidity-indexes.spec.ts
@@ -1,0 +1,123 @@
+import {expect} from 'chai';
+import {BigNumber, ethers} from 'ethers';
+import {MAX_UINT_AMOUNT} from '../helpers/constants';
+import {makeSuite, TestEnv} from './helpers/make-suite';
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {
+  evmSnapshot,
+  evmRevert,
+  MockFlashLoanReceiver,
+  getMockFlashLoanReceiver,
+} from '@aave/deploy-v3';
+import './helpers/utils/wadraymath';
+
+declare var hre: HardhatRuntimeEnvironment;
+
+makeSuite('Pool: liquidity indexes misc tests', (testEnv: TestEnv) => {
+  const TOTAL_PREMIUM = 9;
+  const PREMIUM_TO_PROTOCOL = 3000;
+
+  let _mockFlashLoanReceiver = {} as MockFlashLoanReceiver;
+
+  let snap: string;
+
+  const setupForFlashloan = async (testEnv: TestEnv) => {
+    const {
+      configurator,
+      pool,
+      weth,
+      aave,
+      dai,
+      users: [user0],
+    } = testEnv;
+
+    _mockFlashLoanReceiver = await getMockFlashLoanReceiver();
+
+    await configurator.updateFlashloanPremiumTotal(TOTAL_PREMIUM);
+    await configurator.updateFlashloanPremiumToProtocol(PREMIUM_TO_PROTOCOL);
+
+    const userAddress = user0.address;
+    const amountToDeposit = ethers.utils.parseEther('1');
+
+    await weth['mint(uint256)'](amountToDeposit);
+
+    await weth.approve(pool.address, MAX_UINT_AMOUNT);
+
+    await pool.deposit(weth.address, amountToDeposit, userAddress, '0');
+
+    await aave['mint(uint256)'](amountToDeposit);
+
+    await aave.approve(pool.address, MAX_UINT_AMOUNT);
+
+    await pool.deposit(aave.address, amountToDeposit, userAddress, '0');
+    await dai['mint(uint256)'](amountToDeposit);
+
+    await dai.approve(pool.address, MAX_UINT_AMOUNT);
+
+    await pool.deposit(dai.address, amountToDeposit, userAddress, '0');
+  };
+
+  before(async () => {
+    await setupForFlashloan(testEnv);
+  });
+
+  beforeEach(async () => {
+    snap = await evmSnapshot();
+  });
+
+  afterEach(async () => {
+    await evmRevert(snap);
+  });
+
+  it('Validates that the flash loan fee properly takes into account both aToken supply and accruedToTreasury', async () => {
+    const {
+      pool,
+      helpersContract,
+      weth,
+      aWETH,
+      users: [depositorWeth],
+    } = testEnv;
+
+    /**
+     * 1. Flashes 0.8 WETH
+     * 2. Flashes again 0.8 ETH (to have accruedToTreasury)
+     * 3. Validates that liquidity index took into account both aToken supply and accruedToTreasury
+     */
+
+    const wethFlashBorrowedAmount = ethers.utils.parseEther('0.8');
+
+    await pool.flashLoan(
+      _mockFlashLoanReceiver.address,
+      [weth.address],
+      [wethFlashBorrowedAmount],
+      [0],
+      _mockFlashLoanReceiver.address,
+      '0x10',
+      '0'
+    );
+
+    await pool.flashLoan(
+      _mockFlashLoanReceiver.address,
+      [weth.address],
+      [wethFlashBorrowedAmount],
+      [0],
+      _mockFlashLoanReceiver.address,
+      '0x10',
+      '0'
+    );
+
+    const wethReserveDataAfterSecondFlash = await helpersContract.getReserveData(weth.address);
+
+    const totalScaledWithTreasuryAfterSecondFlash = (
+      await aWETH.scaledBalanceOf(depositorWeth.address)
+    ).add(wethReserveDataAfterSecondFlash.accruedToTreasuryScaled.toString());
+
+    expect(await weth.balanceOf(aWETH.address)).to.be.closeTo(
+      BigNumber.from(totalScaledWithTreasuryAfterSecondFlash.toString()).rayMul(
+        wethReserveDataAfterSecondFlash.liquidityIndex
+      ),
+      1,
+      'Scaled total supply not (+/- 1) equal to WETH balance of aWETH'
+    );
+  });
+});

--- a/test-suites/pool-drop-reserve.spec.ts
+++ b/test-suites/pool-drop-reserve.spec.ts
@@ -10,7 +10,7 @@ makeSuite('Pool: Drop Reserve', (testEnv: TestEnv) => {
   let _mockFlashLoanReceiver = {} as MockFlashLoanReceiver;
 
   const {
-    ATOKEN_SUPPLY_NOT_ZERO,
+    UNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO,
     STABLE_DEBT_NOT_ZERO,
     VARIABLE_DEBT_SUPPLY_NOT_ZERO,
     ASSET_NOT_LISTED,
@@ -46,7 +46,7 @@ makeSuite('Pool: Drop Reserve', (testEnv: TestEnv) => {
 
     await pool.deposit(dai.address, depositedAmount, deployer.address, 0);
 
-    await expect(configurator.dropReserve(dai.address)).to.be.revertedWith(ATOKEN_SUPPLY_NOT_ZERO);
+    await expect(configurator.dropReserve(dai.address)).to.be.revertedWith(UNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO);
 
     await pool.connect(user1.signer).deposit(weth.address, depositedAmount, user1.address, 0);
 
@@ -71,7 +71,7 @@ makeSuite('Pool: Drop Reserve', (testEnv: TestEnv) => {
     );
 
     expect(await pool.connect(user1.signer).repay(dai.address, MAX_UINT_AMOUNT, 2, user1.address));
-    await expect(configurator.dropReserve(dai.address)).to.be.revertedWith(ATOKEN_SUPPLY_NOT_ZERO);
+    await expect(configurator.dropReserve(dai.address)).to.be.revertedWith(UNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO);
   });
 
   it('User 1 withdraw DAI, drop DAI reserve should succeed', async () => {

--- a/test-suites/pool-edge.spec.ts
+++ b/test-suites/pool-edge.spec.ts
@@ -1,14 +1,20 @@
-import { expect } from 'chai';
-import { BigNumber, BigNumberish, utils } from 'ethers';
-import { impersonateAccountsHardhat } from '../helpers/misc-utils';
-import { MAX_UINT_AMOUNT, ZERO_ADDRESS } from '../helpers/constants';
-import { deployMintableERC20 } from '@aave/deploy-v3/dist/helpers/contract-deployments';
-import { ProtocolErrors } from '../helpers/types';
-import { getFirstSigner } from '@aave/deploy-v3/dist/helpers/utilities/signer';
-import { topUpNonPayableWithEther } from './helpers/utils/funds';
-import { makeSuite, TestEnv } from './helpers/make-suite';
-import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { evmSnapshot, evmRevert, getPoolLibraries } from '@aave/deploy-v3';
+import {expect} from 'chai';
+import {BigNumber, BigNumberish, utils} from 'ethers';
+import {impersonateAccountsHardhat} from '../helpers/misc-utils';
+import {MAX_UINT_AMOUNT, ZERO_ADDRESS} from '../helpers/constants';
+import {deployMintableERC20} from '@aave/deploy-v3/dist/helpers/contract-deployments';
+import {ProtocolErrors} from '../helpers/types';
+import {getFirstSigner} from '@aave/deploy-v3/dist/helpers/utilities/signer';
+import {topUpNonPayableWithEther} from './helpers/utils/funds';
+import {makeSuite, TestEnv} from './helpers/make-suite';
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {
+  evmSnapshot,
+  evmRevert,
+  getPoolLibraries,
+  MockFlashLoanReceiver,
+  getMockFlashLoanReceiver,
+} from '@aave/deploy-v3';
 import {
   MockPoolInherited__factory,
   MockReserveInterestRateStrategy__factory,
@@ -16,10 +22,10 @@ import {
   VariableDebtToken__factory,
   AToken__factory,
   Pool__factory,
-  InitializableImmutableAdminUpgradeabilityProxy,
   ERC20__factory,
 } from '../types';
-import { getProxyImplementation } from '../helpers/contracts-helpers';
+import {getProxyImplementation} from '../helpers/contracts-helpers';
+import {ethers} from 'hardhat';
 
 declare var hre: HardhatRuntimeEnvironment;
 
@@ -35,14 +41,21 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
     DEBT_CEILING_NOT_ZERO,
     ASSET_NOT_LISTED,
     ZERO_ADDRESS_NOT_VALID,
+    UNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO,
+    SUPPLY_CAP_EXCEEDED,
+    RESERVE_LIQUIDITY_NOT_ZERO,
   } = ProtocolErrors;
 
   const MAX_STABLE_RATE_BORROW_SIZE_PERCENT = 2500;
   const MAX_NUMBER_RESERVES = 128;
+  const TOTAL_PREMIUM = 9;
+  const PREMIUM_TO_PROTOCOL = 3000;
 
   const POOL_ID = utils.formatBytes32String('POOL');
 
   let snap: string;
+
+  let _mockFlashLoanReceiver = {} as MockFlashLoanReceiver;
 
   beforeEach(async () => {
     snap = await evmSnapshot();
@@ -59,7 +72,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
       dai,
       users: [user0],
     } = testEnv;
-    const { deployer: deployerName } = await hre.getNamedAccounts();
+    const {deployer: deployerName} = await hre.getNamedAccounts();
 
     // Deploy the mock Pool with a `dropReserve` skipping the checks
     const NEW_POOL_IMPL_ARTIFACT = await hre.deployments.deploy('MockPoolInheritedDropper', {
@@ -129,7 +142,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
       addressesProvider,
       users: [deployer],
     } = testEnv;
-    const { deployer: deployerName } = await hre.getNamedAccounts();
+    const {deployer: deployerName} = await hre.getNamedAccounts();
 
     const NEW_POOL_IMPL_ARTIFACT = await hre.deployments.deploy('Pool', {
       contract: 'Pool',
@@ -155,7 +168,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
   });
 
   it('Check initialization', async () => {
-    const { pool } = testEnv;
+    const {pool} = testEnv;
 
     expect(await pool.MAX_STABLE_RATE_BORROW_SIZE_PERCENT()).to.be.eq(
       MAX_STABLE_RATE_BORROW_SIZE_PERCENT
@@ -164,7 +177,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
   });
 
   it('Tries to initialize a reserve as non PoolConfigurator (revert expected)', async () => {
-    const { pool, users, dai, helpersContract } = testEnv;
+    const {pool, users, dai, helpersContract} = testEnv;
 
     const config = await helpersContract.getReserveTokensAddresses(dai.address);
 
@@ -249,7 +262,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
   });
 
   it('Call `mintToTreasury()` on a pool with an inactive reserve', async () => {
-    const { pool, poolAdmin, dai, users, configurator } = testEnv;
+    const {pool, poolAdmin, dai, users, configurator} = testEnv;
 
     // Deactivate reserve
     expect(await configurator.connect(poolAdmin.signer).setReserveActive(dai.address, false));
@@ -259,7 +272,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
   });
 
   it('Tries to call `finalizeTransfer()` by a non-aToken address (revert expected)', async () => {
-    const { pool, dai, users } = testEnv;
+    const {pool, dai, users} = testEnv;
 
     await expect(
       pool
@@ -269,7 +282,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
   });
 
   it('Tries to call `initReserve()` with an EOA as reserve (revert expected)', async () => {
-    const { pool, deployer, users, configurator } = testEnv;
+    const {pool, deployer, users, configurator} = testEnv;
 
     // Impersonate PoolConfigurator
     await topUpNonPayableWithEther(deployer.signer, [configurator.address], utils.parseEther('1'));
@@ -284,7 +297,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
   });
 
   it('PoolConfigurator updates the ReserveInterestRateStrategy address', async () => {
-    const { pool, deployer, dai, configurator } = testEnv;
+    const {pool, deployer, dai, configurator} = testEnv;
 
     // Impersonate PoolConfigurator
     await topUpNonPayableWithEther(deployer.signer, [configurator.address], utils.parseEther('1'));
@@ -302,7 +315,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
   });
 
   it('PoolConfigurator updates the ReserveInterestRateStrategy address for asset 0', async () => {
-    const { pool, deployer, dai, configurator } = testEnv;
+    const {pool, deployer, dai, configurator} = testEnv;
 
     // Impersonate PoolConfigurator
     await topUpNonPayableWithEther(deployer.signer, [configurator.address], utils.parseEther('1'));
@@ -315,7 +328,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
   });
 
   it('PoolConfigurator updates the ReserveInterestRateStrategy address for an unlisted asset (revert expected)', async () => {
-    const { pool, deployer, dai, configurator, users } = testEnv;
+    const {pool, deployer, dai, configurator, users} = testEnv;
 
     // Impersonate PoolConfigurator
     await topUpNonPayableWithEther(deployer.signer, [configurator.address], utils.parseEther('1'));
@@ -330,14 +343,14 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
   });
 
   it('Activates the zero address reserve for borrowing via pool admin (expect revert)', async () => {
-    const { configurator } = testEnv;
+    const {configurator} = testEnv;
     await expect(configurator.setReserveBorrowing(ZERO_ADDRESS, true)).to.be.revertedWith(
       ZERO_ADDRESS_NOT_VALID
     );
   });
 
   it('Initialize an already initialized reserve. ReserveLogic `init` where aTokenAddress != ZERO_ADDRESS (revert expected)', async () => {
-    const { pool, dai, deployer, configurator } = testEnv;
+    const {pool, dai, deployer, configurator} = testEnv;
 
     // Impersonate PoolConfigurator
     await topUpNonPayableWithEther(deployer.signer, [configurator.address], utils.parseEther('1'));
@@ -363,7 +376,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
      * `_addReserveToList()` is called from `initReserve`. However, in `initReserve` we run `init` before the `_addReserveToList()`,
      * and in `init` we are checking if `aTokenAddress == address(0)`, so to bypass that we need this odd init.
      */
-    const { pool, dai, deployer, configurator } = testEnv;
+    const {pool, dai, deployer, configurator} = testEnv;
 
     // Impersonate PoolConfigurator
     await topUpNonPayableWithEther(deployer.signer, [configurator.address], utils.parseEther('1'));
@@ -406,8 +419,8 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
 
   it('Initialize reserves until max, then add one more (revert expected)', async () => {
     // Upgrade the Pool to update the maximum number of reserves
-    const { addressesProvider, poolAdmin, pool, dai, deployer, configurator } = testEnv;
-    const { deployer: deployerName } = await hre.getNamedAccounts();
+    const {addressesProvider, poolAdmin, pool, dai, deployer, configurator} = testEnv;
+    const {deployer: deployerName} = await hre.getNamedAccounts();
 
     // Impersonate the PoolConfigurator
     await topUpNonPayableWithEther(deployer.signer, [configurator.address], utils.parseEther('1'));
@@ -475,7 +488,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
      * 3. Init a new asset.
      * Intended behaviour new asset is inserted into one of the available spots in
      */
-    const { configurator, pool, poolAdmin, addressesProvider } = testEnv;
+    const {configurator, pool, poolAdmin, addressesProvider} = testEnv;
 
     const reservesListBefore = await pool.connect(configurator.signer).getReservesList();
 
@@ -574,8 +587,8 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
      */
 
     // Upgrade the Pool to update the maximum number of reserves
-    const { addressesProvider, poolAdmin, pool, dai, deployer, configurator } = testEnv;
-    const { deployer: deployerName } = await hre.getNamedAccounts();
+    const {addressesProvider, poolAdmin, pool, dai, deployer, configurator} = testEnv;
+    const {deployer: deployerName} = await hre.getNamedAccounts();
 
     // Impersonate the PoolConfigurator
     await topUpNonPayableWithEther(deployer.signer, [configurator.address], utils.parseEther('1'));
@@ -707,7 +720,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
   });
 
   it('Tries to initialize a reserve with an AToken, StableDebtToken, and VariableDebt each deployed with the wrong pool address (revert expected)', async () => {
-    const { pool, deployer, configurator, addressesProvider } = testEnv;
+    const {pool, deployer, configurator, addressesProvider} = testEnv;
 
     const NEW_POOL_IMPL_ARTIFACT = await hre.deployments.deploy('DummyPool', {
       contract: 'Pool',
@@ -792,5 +805,163 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
 
     initInputParams[0].variableDebtTokenImpl = variableDebtTokenImp.address;
     expect(await configurator.initReserves(initInputParams));
+  });
+
+  it('dropReserve(). Only allows to drop a reserve if both the aToken supply and accruedToTreasury are 0', async () => {
+    const {
+      configurator,
+      pool,
+      weth,
+      aWETH,
+      dai,
+      users: [user0],
+    } = testEnv;
+
+    _mockFlashLoanReceiver = await getMockFlashLoanReceiver();
+
+    await configurator.updateFlashloanPremiumTotal(TOTAL_PREMIUM);
+    await configurator.updateFlashloanPremiumToProtocol(PREMIUM_TO_PROTOCOL);
+
+    const userAddress = user0.address;
+    const amountToDeposit = ethers.utils.parseEther('1');
+
+    await weth['mint(uint256)'](amountToDeposit);
+
+    await weth.approve(pool.address, MAX_UINT_AMOUNT);
+
+    await pool.deposit(weth.address, amountToDeposit, userAddress, '0');
+
+    const wethFlashBorrowedAmount = ethers.utils.parseEther('0.8');
+
+    await pool.flashLoan(
+      _mockFlashLoanReceiver.address,
+      [weth.address],
+      [wethFlashBorrowedAmount],
+      [0],
+      _mockFlashLoanReceiver.address,
+      '0x10',
+      '0'
+    );
+
+    await pool.connect(user0.signer).withdraw(weth.address, MAX_UINT_AMOUNT, userAddress);
+
+    await expect(
+      configurator.dropReserve(weth.address),
+      'dropReserve() should not be possible as there are funds'
+    ).to.be.revertedWith(UNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO);
+
+    await pool.mintToTreasury([weth.address]);
+
+    // Impersonate Collector
+    const collectorAddress = await aWETH.RESERVE_TREASURY_ADDRESS();
+    await topUpNonPayableWithEther(user0.signer, [collectorAddress], utils.parseEther('1'));
+    await impersonateAccountsHardhat([collectorAddress]);
+    const collectorSigner = await hre.ethers.getSigner(collectorAddress);
+    await pool.connect(collectorSigner).withdraw(weth.address, MAX_UINT_AMOUNT, collectorAddress);
+
+    await configurator.dropReserve(weth.address);
+  });
+
+  it('validateSupply(). Only allows to supply if amount + (scaled aToken supply + accruedToTreasury) <= supplyCap', async () => {
+    const {
+      configurator,
+      pool,
+      weth,
+      aWETH,
+      users: [user0],
+    } = testEnv;
+
+    _mockFlashLoanReceiver = await getMockFlashLoanReceiver();
+
+    await configurator.updateFlashloanPremiumTotal(TOTAL_PREMIUM);
+    await configurator.updateFlashloanPremiumToProtocol(PREMIUM_TO_PROTOCOL);
+
+    const userAddress = user0.address;
+    const amountToDeposit = ethers.utils.parseEther('100000');
+
+    await weth['mint(uint256)'](amountToDeposit.add(ethers.utils.parseEther('30')));
+
+    await weth.approve(pool.address, MAX_UINT_AMOUNT);
+
+    await pool.deposit(weth.address, amountToDeposit, userAddress, '0');
+
+    const wethFlashBorrowedAmount = ethers.utils.parseEther('100000');
+
+    await pool.flashLoan(
+      _mockFlashLoanReceiver.address,
+      [weth.address],
+      [wethFlashBorrowedAmount],
+      [0],
+      _mockFlashLoanReceiver.address,
+      '0x10',
+      '0'
+    );
+
+    // At this point the totalSupply + accruedToTreasury is ~100090 WETH, with 100063 from supply and ~27 from accruedToTreasury
+    // so to properly test the supply cap condition:
+    // - Set supply cap above that, at 110 WETH
+    // - Try to supply 30 WETH more . Should work if not taken into account accruedToTreasury, but will not
+    // - Try to supply 5 WETH more. Should work
+
+    await configurator.setSupplyCap(weth.address, BigNumber.from('100000').add('110'));
+
+    await expect(
+      pool.deposit(weth.address, ethers.utils.parseEther('30'), userAddress, '0')
+    ).to.be.revertedWith(SUPPLY_CAP_EXCEEDED);
+
+    await pool.deposit(weth.address, ethers.utils.parseEther('5'), userAddress, '0');
+  });
+
+  it('_checkNoSuppliers() (PoolConfigurator). Properly disables actions if aToken supply == 0, but accruedToTreasury != 0', async () => {
+    const {
+      configurator,
+      pool,
+      weth,
+      aWETH,
+      users: [user0],
+    } = testEnv;
+
+    _mockFlashLoanReceiver = await getMockFlashLoanReceiver();
+
+    await configurator.updateFlashloanPremiumTotal(TOTAL_PREMIUM);
+    await configurator.updateFlashloanPremiumToProtocol(PREMIUM_TO_PROTOCOL);
+
+    const userAddress = user0.address;
+    const amountToDeposit = ethers.utils.parseEther('100000');
+
+    await weth['mint(uint256)'](amountToDeposit.add(ethers.utils.parseEther('30')));
+
+    await weth.approve(pool.address, MAX_UINT_AMOUNT);
+
+    await pool.deposit(weth.address, amountToDeposit, userAddress, '0');
+
+    const wethFlashBorrowedAmount = ethers.utils.parseEther('100000');
+
+    await pool.flashLoan(
+      _mockFlashLoanReceiver.address,
+      [weth.address],
+      [wethFlashBorrowedAmount],
+      [0],
+      _mockFlashLoanReceiver.address,
+      '0x10',
+      '0'
+    );
+
+    await pool.connect(user0.signer).withdraw(weth.address, MAX_UINT_AMOUNT, userAddress);
+
+    await expect(configurator.setReserveActive(weth.address, false)).to.be.revertedWith(
+      RESERVE_LIQUIDITY_NOT_ZERO
+    );
+
+    await pool.mintToTreasury([weth.address]);
+
+    // Impersonate Collector
+    const collectorAddress = await aWETH.RESERVE_TREASURY_ADDRESS();
+    await topUpNonPayableWithEther(user0.signer, [collectorAddress], utils.parseEther('1'));
+    await impersonateAccountsHardhat([collectorAddress]);
+    const collectorSigner = await hre.ethers.getSigner(collectorAddress);
+    await pool.connect(collectorSigner).withdraw(weth.address, MAX_UINT_AMOUNT, collectorAddress);
+
+    await configurator.setReserveActive(weth.address, false);
   });
 });


### PR DESCRIPTION
https://github.com/aave/aave-v3-core/issues/730

The changes included in this PR are the following:
- [x] On both `FlashLoan` and `BridgeLogic` the accumulation to the liquidity index now includes both aToken supply and scaled-up accruedToTreasury.
- [x] On `ValidationLogic`, now `validateSupply()` takes into account accruedToTreasury, to not allow deposits when (aToken supply + scaled-up accruedToTreasury) is bigger than the supply cap. 
- [x] Also on `ValidationLogic`,  `validateDropReserve` now checks that **both** aToken supply and accruedToTreasury are 0.
- [x] On `PoolConfigurator`, `_checkNoSuppliers()` checks that accruedToTreasury is 0, as factually the Collector is a depositor in that case, even if not holding aToken.
- [x] Tests for the most important fix, affecting flash loan fee (and bridge fee, but it is exactly the same)
- [x] Test for fixes on validations 
