### PR TITLE
Make AToken's initialize and _transfer functions virtual so they can be extended

### DIFF
--- a/contracts/protocol/tokenization/AToken.sol
+++ b/contracts/protocol/tokenization/AToken.sol
@@ -235,7 +235,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
     address from,
     address to,
     uint128 amount
-  ) internal override {
+  ) internal virtual override {
     _transfer(from, to, amount, true);
   }
 

--- a/contracts/protocol/tokenization/AToken.sol
+++ b/contracts/protocol/tokenization/AToken.sol
@@ -59,7 +59,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
     string calldata aTokenName,
     string calldata aTokenSymbol,
     bytes calldata params
-  ) external override initializer {
+  ) public virtual override initializer {
     require(initializingPool == POOL, Errors.POOL_ADDRESSES_DO_NOT_MATCH);
     _setName(aTokenName);
     _setSymbol(aTokenSymbol);

--- a/contracts/protocol/tokenization/AToken.sol
+++ b/contracts/protocol/tokenization/AToken.sol
@@ -208,7 +208,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
     address to,
     uint256 amount,
     bool validate
-  ) internal {
+  ) internal virtual {
     address underlyingAsset = _underlyingAsset;
 
     uint256 index = POOL.getReserveNormalizedIncome(underlyingAsset);


### PR DESCRIPTION
This is a follow up to https://github.com/aave/aave-v3-core/pull/726

It does two things:
* makes [`aToken.intialize`](https://github.com/aave/aave-v3-core/blob/f3e037b3638e3b7c98f0c09c56c5efde54f7c5d2/contracts/protocol/tokenization/AToken.sol#L53-L62) public and virtual
* makes [`aToken._transfer`](https://github.com/aave/aave-v3-core/blob/f3e037b3638e3b7c98f0c09c56c5efde54f7c5d2/contracts/protocol/tokenization/AToken.sol#L206-L211) virtual

Doing so will make `AToken` easier to extend, e.g. for [grant-funded projects](https://twitter.com/AaveGrants/status/1586858440080572417) like [the one I'm working on](https://hackmd.io/@scopelift/Syg2nuNMo).

I'd like `initialize()` to be public as well so that the override can just call `super.initialize(...)` to inherit all the current functionality without having to copy/paste it.