### PR TITLE
Soften IERC20 versioning

### DIFF
--- a/contracts/dependencies/openzeppelin/contracts/IERC20.sol
+++ b/contracts/dependencies/openzeppelin/contracts/IERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.


### PR DESCRIPTION
It is problematic to have strict versioning in internal dependencies of contracts, especially those thought to be used/deployed partially in isolation (e.g. `DefaultReserveInterestRateStrategy`).

This just updates IERC20 from dependencies, as it is blocking for Aave v3 Ethereum