### PR TITLE
chore: bump revisions

### DIFF
--- a/contracts/protocol/pool/Pool.sol
+++ b/contracts/protocol/pool/Pool.sol
@@ -39,7 +39,7 @@ import {PoolStorage} from './PoolStorage.sol';
 contract Pool is VersionedInitializable, PoolStorage, IPool {
   using ReserveLogic for DataTypes.ReserveData;
 
-  uint256 public constant POOL_REVISION = 0x1;
+  uint256 public constant POOL_REVISION = 0x2;
   IPoolAddressesProvider public immutable ADDRESSES_PROVIDER;
 
   /**

--- a/contracts/protocol/pool/PoolConfigurator.sol
+++ b/contracts/protocol/pool/PoolConfigurator.sol
@@ -66,10 +66,10 @@ contract PoolConfigurator is VersionedInitializable, IPoolConfigurator {
     _;
   }
 
-  uint256 public constant CONFIGURATOR_REVISION = 0x1;
+  uint256 public constant CONFIGURATOR_REVISION = 0x2;
 
   /// @inheritdoc VersionedInitializable
-  function getRevision() internal pure virtual override returns (uint256) {
+  function getRevision() internal virtual override pure returns (uint256) {
     return CONFIGURATOR_REVISION;
   }
 
@@ -495,7 +495,8 @@ contract PoolConfigurator is VersionedInitializable, IPoolConfigurator {
   function _checkNoSuppliers(address asset) internal view {
     (, uint256 accruedToTreasury, uint256 totalATokens, , , , , , , , , ) = IPoolDataProvider(
       _addressesProvider.getPoolDataProvider()
-    ).getReserveData(asset);
+    )
+      .getReserveData(asset);
 
     require(totalATokens == 0 && accruedToTreasury == 0, Errors.RESERVE_LIQUIDITY_NOT_ZERO);
   }

--- a/contracts/protocol/tokenization/AToken.sol
+++ b/contracts/protocol/tokenization/AToken.sol
@@ -28,7 +28,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
   bytes32 public constant PERMIT_TYPEHASH =
     keccak256('Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)');
 
-  uint256 public constant ATOKEN_REVISION = 0x1;
+  uint256 public constant ATOKEN_REVISION = 0x2;
 
   address internal _treasury;
   address internal _underlyingAsset;

--- a/contracts/protocol/tokenization/StableDebtToken.sol
+++ b/contracts/protocol/tokenization/StableDebtToken.sol
@@ -26,7 +26,7 @@ contract StableDebtToken is DebtTokenBase, IncentivizedERC20, IStableDebtToken {
   using WadRayMath for uint256;
   using SafeCast for uint256;
 
-  uint256 public constant DEBT_TOKEN_REVISION = 0x1;
+  uint256 public constant DEBT_TOKEN_REVISION = 0x2;
 
   // Map of users address and the timestamp of their last update (userAddress => lastUpdateTimestamp)
   mapping(address => uint40) internal _timestamps;

--- a/contracts/protocol/tokenization/VariableDebtToken.sol
+++ b/contracts/protocol/tokenization/VariableDebtToken.sol
@@ -25,7 +25,7 @@ contract VariableDebtToken is DebtTokenBase, ScaledBalanceTokenBase, IVariableDe
   using WadRayMath for uint256;
   using SafeCast for uint256;
 
-  uint256 public constant DEBT_TOKEN_REVISION = 0x1;
+  uint256 public constant DEBT_TOKEN_REVISION = 0x2;
 
   /**
    * @dev Constructor.


### PR DESCRIPTION
This branch will be used for 3.0.1 upgrades on various networks

Personally i think this should be considered to be merged as not bumping revisions forces ppl to do weird tricks(like this one) or to copy contracts. To me it would seems reasonable to bump the revisions as for new deployments starting with `rev x` is not a problem, but for existing ones the static rev 0x1 makes upgrades harder.

Imo revision should reflect the revision of the contract. Not the number of deployments on a specific network.

It's `641c12a89556645fa8705d7d821060fcad1aea4b` with applied rev changes.