### PR TITLE
fix: expose error list and types at npm package

### DIFF
--- a/helper-hardhat-config.ts
+++ b/helper-hardhat-config.ts
@@ -18,10 +18,10 @@ export const buildForkConfig = (): HardhatNetworkForkingUserConfig | undefined =
   let forkMode: HardhatNetworkForkingUserConfig | undefined;
   if (FORK) {
     forkMode = {
-      url: NETWORKS_RPC_URL[FORK],
+      url: NETWORKS_RPC_URL[FORK as eEthereumNetwork],
     };
-    if (FORK_BLOCK_NUMBER || BLOCK_TO_FORK[FORK]) {
-      forkMode.blockNumber = FORK_BLOCK_NUMBER || BLOCK_TO_FORK[FORK];
+    if (FORK_BLOCK_NUMBER || BLOCK_TO_FORK[FORK as eEthereumNetwork]) {
+      forkMode.blockNumber = FORK_BLOCK_NUMBER || BLOCK_TO_FORK[FORK as eEthereumNetwork];
     }
   }
   return forkMode;

--- a/helpers/contracts-helpers.ts
+++ b/helpers/contracts-helpers.ts
@@ -2,15 +2,12 @@ import { ethers } from 'ethers';
 import { signTypedData_v4 } from 'eth-sig-util';
 import { fromRpcSig, ECDSASignature } from 'ethereumjs-util';
 import { tEthereumAddress, tStringTokenSmallUnits } from './types';
-import { MintableERC20 } from '../types/MintableERC20';
 import { getContract } from '@aave/deploy-v3';
 import { impersonateAccountsHardhat } from './misc-utils';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { InitializableImmutableAdminUpgradeabilityProxy } from '../types';
 
 declare var hre: HardhatRuntimeEnvironment;
-
-export type MockTokenMap = { [symbol: string]: MintableERC20 };
 
 export const convertToCurrencyDecimals = async (tokenAddress: tEthereumAddress, amount: string) => {
   const token = await getContract('IERC20Detailed', tokenAddress);

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -1,0 +1,3 @@
+export * from './constants';
+export * from './types';
+export * from './contracts-helpers';

--- a/lib.tsconfig.json
+++ b/lib.tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist/",
+    "importHelpers": false,
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "dist/types",
+    "typeRoots": ["./typechain/*.d.ts", "./node_modules/@types"]
+  },
+  "include": ["helpers", "types", "hardhat.config.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "dotenv": "8.2.0",
         "eth-sig-util": "2.5.3",
         "ethereumjs-util": "7.0.2",
-        "ethers": "5.6.9",
+        "ethers": "5.7.2",
         "hardhat": "2.12.2",
         "hardhat-contract-sizer": "2.0.3",
         "hardhat-dependency-compiler": "1.1.2",
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@ethersproject/contracts": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.2.tgz",
-      "integrity": "sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
       "dev": true,
       "funding": [
         {
@@ -379,16 +379,16 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "^5.6.3",
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2"
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hash": {
@@ -419,9 +419,9 @@
       }
     },
     "node_modules/@ethersproject/hdnode": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
-      "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "dev": true,
       "funding": [
         {
@@ -434,24 +434,24 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/json-wallets": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
-      "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "dev": true,
       "funding": [
         {
@@ -464,17 +464,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
@@ -535,9 +535,9 @@
       }
     },
     "node_modules/@ethersproject/pbkdf2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
-      "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "dev": true,
       "funding": [
         {
@@ -550,8 +550,8 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/properties": {
@@ -588,7 +588,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -698,9 +697,9 @@
       }
     },
     "node_modules/@ethersproject/solidity": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.1.tgz",
-      "integrity": "sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
       "dev": true,
       "funding": [
         {
@@ -713,12 +712,12 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/strings": {
@@ -770,9 +769,9 @@
       }
     },
     "node_modules/@ethersproject/units": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.1.tgz",
-      "integrity": "sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
       "dev": true,
       "funding": [
         {
@@ -785,15 +784,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wallet": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
-      "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "dev": true,
       "funding": [
         {
@@ -806,21 +805,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/json-wallets": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/web": {
@@ -847,9 +846,9 @@
       }
     },
     "node_modules/@ethersproject/wordlists": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
-      "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "dev": true,
       "funding": [
         {
@@ -862,11 +861,11 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@metamask/eth-sig-util": {
@@ -4658,9 +4657,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.9.tgz",
-      "integrity": "sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
       "dev": true,
       "funding": [
         {
@@ -4673,526 +4672,36 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "5.6.4",
-        "@ethersproject/abstract-provider": "5.6.1",
-        "@ethersproject/abstract-signer": "5.6.2",
-        "@ethersproject/address": "5.6.1",
-        "@ethersproject/base64": "5.6.1",
-        "@ethersproject/basex": "5.6.1",
-        "@ethersproject/bignumber": "5.6.2",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.1",
-        "@ethersproject/contracts": "5.6.2",
-        "@ethersproject/hash": "5.6.1",
-        "@ethersproject/hdnode": "5.6.2",
-        "@ethersproject/json-wallets": "5.6.1",
-        "@ethersproject/keccak256": "5.6.1",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.4",
-        "@ethersproject/pbkdf2": "5.6.1",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.8",
-        "@ethersproject/random": "5.6.1",
-        "@ethersproject/rlp": "5.6.1",
-        "@ethersproject/sha2": "5.6.1",
-        "@ethersproject/signing-key": "5.6.2",
-        "@ethersproject/solidity": "5.6.1",
-        "@ethersproject/strings": "5.6.1",
-        "@ethersproject/transactions": "5.6.2",
-        "@ethersproject/units": "5.6.1",
-        "@ethersproject/wallet": "5.6.2",
-        "@ethersproject/web": "5.6.1",
-        "@ethersproject/wordlists": "5.6.1"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/abi": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
-      "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/abstract-provider": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
-      "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/address": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/base64": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
-      "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.1"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/basex": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
-      "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/bignumber": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
-      "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "bn.js": "^5.2.1"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/bytes": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/constants": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
-      "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/hash": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
-      "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/keccak256": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
-      "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "js-sha3": "0.8.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/logger": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ]
-    },
-    "node_modules/ethers/node_modules/@ethersproject/networks": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
-      "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/properties": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
-      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/providers": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.8.tgz",
-      "integrity": "sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1",
-        "bech32": "1.1.4",
-        "ws": "7.4.6"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/random": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
-      "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/rlp": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
-      "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/sha2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
-      "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "hash.js": "1.1.7"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/signing-key": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
-      "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "bn.js": "^5.2.1",
-        "elliptic": "6.5.4",
-        "hash.js": "1.1.7"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/strings": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
-      "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/transactions": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
-      "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/web": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
-      "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "node_modules/ethjs-unit": {
@@ -12678,21 +12187,21 @@
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.2.tgz",
-      "integrity": "sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "^5.6.3",
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2"
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       }
     },
     "@ethersproject/hash": {
@@ -12713,42 +12222,42 @@
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
-      "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
-      "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
@@ -12779,13 +12288,13 @@
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
-      "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "@ethersproject/properties": {
@@ -12802,7 +12311,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
       "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -12872,17 +12380,17 @@
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.1.tgz",
-      "integrity": "sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/strings": {
@@ -12914,37 +12422,37 @@
       }
     },
     "@ethersproject/units": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.1.tgz",
-      "integrity": "sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
-      "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/json-wallets": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "@ethersproject/web": {
@@ -12961,16 +12469,16 @@
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
-      "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@metamask/eth-sig-util": {
@@ -16034,313 +15542,41 @@
       }
     },
     "ethers": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.9.tgz",
-      "integrity": "sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "5.6.4",
-        "@ethersproject/abstract-provider": "5.6.1",
-        "@ethersproject/abstract-signer": "5.6.2",
-        "@ethersproject/address": "5.6.1",
-        "@ethersproject/base64": "5.6.1",
-        "@ethersproject/basex": "5.6.1",
-        "@ethersproject/bignumber": "5.6.2",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.1",
-        "@ethersproject/contracts": "5.6.2",
-        "@ethersproject/hash": "5.6.1",
-        "@ethersproject/hdnode": "5.6.2",
-        "@ethersproject/json-wallets": "5.6.1",
-        "@ethersproject/keccak256": "5.6.1",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.4",
-        "@ethersproject/pbkdf2": "5.6.1",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.8",
-        "@ethersproject/random": "5.6.1",
-        "@ethersproject/rlp": "5.6.1",
-        "@ethersproject/sha2": "5.6.1",
-        "@ethersproject/signing-key": "5.6.2",
-        "@ethersproject/solidity": "5.6.1",
-        "@ethersproject/strings": "5.6.1",
-        "@ethersproject/transactions": "5.6.2",
-        "@ethersproject/units": "5.6.1",
-        "@ethersproject/wallet": "5.6.2",
-        "@ethersproject/web": "5.6.1",
-        "@ethersproject/wordlists": "5.6.1"
-      },
-      "dependencies": {
-        "@ethersproject/abi": {
-          "version": "5.6.4",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
-          "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/address": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/constants": "^5.6.1",
-            "@ethersproject/hash": "^5.6.1",
-            "@ethersproject/keccak256": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/strings": "^5.6.1"
-          }
-        },
-        "@ethersproject/abstract-provider": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
-          "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/networks": "^5.6.3",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/transactions": "^5.6.2",
-            "@ethersproject/web": "^5.6.1"
-          }
-        },
-        "@ethersproject/abstract-signer": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-          "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0"
-          }
-        },
-        "@ethersproject/address": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-          "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/keccak256": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/rlp": "^5.6.1"
-          }
-        },
-        "@ethersproject/base64": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
-          "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.6.1"
-          }
-        },
-        "@ethersproject/basex": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
-          "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/properties": "^5.6.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
-          "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "bn.js": "^5.2.1"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-          "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/constants": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
-          "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bignumber": "^5.6.2"
-          }
-        },
-        "@ethersproject/hash": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
-          "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.6.2",
-            "@ethersproject/address": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/keccak256": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/strings": "^5.6.1"
-          }
-        },
-        "@ethersproject/keccak256": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
-          "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.6.1",
-            "js-sha3": "0.8.0"
-          }
-        },
-        "@ethersproject/logger": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-          "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
-          "dev": true
-        },
-        "@ethersproject/networks": {
-          "version": "5.6.4",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
-          "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/properties": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
-          "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/providers": {
-          "version": "5.6.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.8.tgz",
-          "integrity": "sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.6.1",
-            "@ethersproject/abstract-signer": "^5.6.2",
-            "@ethersproject/address": "^5.6.1",
-            "@ethersproject/base64": "^5.6.1",
-            "@ethersproject/basex": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/constants": "^5.6.1",
-            "@ethersproject/hash": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/networks": "^5.6.3",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/random": "^5.6.1",
-            "@ethersproject/rlp": "^5.6.1",
-            "@ethersproject/sha2": "^5.6.1",
-            "@ethersproject/strings": "^5.6.1",
-            "@ethersproject/transactions": "^5.6.2",
-            "@ethersproject/web": "^5.6.1",
-            "bech32": "1.1.4",
-            "ws": "7.4.6"
-          }
-        },
-        "@ethersproject/random": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
-          "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/rlp": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
-          "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/sha2": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
-          "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "hash.js": "1.1.7"
-          }
-        },
-        "@ethersproject/signing-key": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
-          "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "bn.js": "^5.2.1",
-            "elliptic": "6.5.4",
-            "hash.js": "1.1.7"
-          }
-        },
-        "@ethersproject/strings": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
-          "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/constants": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
-          "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/address": "^5.6.1",
-            "@ethersproject/bignumber": "^5.6.2",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/constants": "^5.6.1",
-            "@ethersproject/keccak256": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/rlp": "^5.6.1",
-            "@ethersproject/signing-key": "^5.6.2"
-          }
-        },
-        "@ethersproject/web": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
-          "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/base64": "^5.6.1",
-            "@ethersproject/bytes": "^5.6.1",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/strings": "^5.6.1"
-          }
-        }
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "ethjs-unit": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dotenv": "8.2.0",
     "eth-sig-util": "2.5.3",
     "ethereumjs-util": "7.0.2",
-    "ethers": "5.6.9",
+    "ethers": "5.7.2",
     "hardhat": "2.12.2",
     "hardhat-contract-sizer": "2.0.3",
     "hardhat-dependency-compiler": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "files": [
     "contracts",
     "artifacts",
-    "types"
+    "types",
+    "dist"
   ],
+  "main": "dist/helpers/index.js",
   "engines": {
     "node": ">=16.0.0"
   },
@@ -26,7 +28,8 @@
     "test-subgraph:scenarios": ". ./setup-test-env.sh  && hardhat --network hardhatevm_docker test test-suites/__setup.spec.ts test-suites/subgraph-scenarios.spec.ts",
     "ci:test": ". ./setup-test-env.sh  && npm run test",
     "ci:clean": "rm -rf ./artifacts ./cache ./types ./temp-artifacts",
-    "prepublish": "npm run compile"
+    "build": "tsc --project lib.tsconfig.json",
+    "prepublish": "npm run compile && npm run build"
   },
   "devDependencies": {
     "@aave/deploy-v3": "1.51.0",


### PR DESCRIPTION
- Build typescript project at CI to export `helpers/index.ts` that exports types, contract helpers and constants of `@aave/core-v3` npm package