### PR TITLE
fix: await emit

### DIFF
--- a/test-suites/aave-oracle.spec.ts
+++ b/test-suites/aave-oracle.spec.ts
@@ -45,8 +45,8 @@ makeSuite('AaveOracle', (testEnv: TestEnv) => {
     expect(priorSourcesPrices).to.eql(['0']);
 
     // Add asset source
-    expect(
-      await aaveOracle
+    await expect(
+      aaveOracle
         .connect(poolAdmin.signer)
         .setAssetSources([mockToken.address], [mockAggregator.address])
     )
@@ -69,10 +69,8 @@ makeSuite('AaveOracle', (testEnv: TestEnv) => {
     expect(daiSource).to.be.not.eq(ZERO_ADDRESS);
 
     // Update DAI source
-    expect(
-      await aaveOracle
-        .connect(poolAdmin.signer)
-        .setAssetSources([dai.address], [mockAggregator.address])
+    await expect(
+      aaveOracle.connect(poolAdmin.signer).setAssetSources([dai.address], [mockAggregator.address])
     )
       .to.emit(aaveOracle, 'AssetSourceUpdated')
       .withArgs(dai.address, mockAggregator.address);
@@ -113,10 +111,8 @@ makeSuite('AaveOracle', (testEnv: TestEnv) => {
     const { poolAdmin, aaveOracle, weth } = testEnv;
 
     // Add asset source for BASE_CURRENCY address
-    expect(
-      await aaveOracle
-        .connect(poolAdmin.signer)
-        .setAssetSources([weth.address], [mockAggregator.address])
+    await expect(
+      aaveOracle.connect(poolAdmin.signer).setAssetSources([weth.address], [mockAggregator.address])
     )
       .to.emit(aaveOracle, 'AssetSourceUpdated')
       .withArgs(weth.address, mockAggregator.address);
@@ -149,8 +145,8 @@ makeSuite('AaveOracle', (testEnv: TestEnv) => {
     expect(await aaveOracle.getSourceOfAsset(mockToken.address)).to.be.eq(ZERO_ADDRESS);
 
     // Add asset source
-    expect(
-      await aaveOracle
+    await expect(
+      aaveOracle
         .connect(poolAdmin.signer)
         .setAssetSources([mockToken.address], [zeroPriceMockAgg.address])
     )
@@ -173,8 +169,8 @@ makeSuite('AaveOracle', (testEnv: TestEnv) => {
     expect(await aaveOracle.getSourceOfAsset(mockToken.address)).to.be.eq(ZERO_ADDRESS);
 
     // Add asset source
-    expect(
-      await aaveOracle
+    await expect(
+      aaveOracle
         .connect(poolAdmin.signer)
         .setAssetSources([mockToken.address], [zeroPriceMockAgg.address])
     )
@@ -191,7 +187,7 @@ makeSuite('AaveOracle', (testEnv: TestEnv) => {
     expect(await aaveOracle.getFallbackOracle()).to.be.eq(oracle.address);
 
     // Update oracle source
-    expect(await aaveOracle.connect(poolAdmin.signer).setFallbackOracle(ONE_ADDRESS))
+    await expect(aaveOracle.connect(poolAdmin.signer).setFallbackOracle(ONE_ADDRESS))
       .to.emit(aaveOracle, 'FallbackOracleUpdated')
       .withArgs(ONE_ADDRESS);
 

--- a/test-suites/aave-protocol-data-provider.spec.ts
+++ b/test-suites/aave-protocol-data-provider.spec.ts
@@ -23,7 +23,7 @@ makeSuite('AaveProtocolDataProvider: Edge cases', (testEnv: TestEnv) => {
     const oldPoolImpl = await getProxyImplementation(addressesProvider.address, poolProxyAddress);
 
     // Update the addressesProvider with a mock pool
-    expect(await addressesProvider.connect(poolAdmin.signer).setPoolImpl(mockPool.address))
+    await expect(addressesProvider.connect(poolAdmin.signer).setPoolImpl(mockPool.address))
       .to.emit(addressesProvider, 'PoolUpdated')
       .withArgs(oldPoolImpl, mockPool.address);
 

--- a/test-suites/addresses-provider-registry.spec.ts
+++ b/test-suites/addresses-provider-registry.spec.ts
@@ -40,8 +40,8 @@ makeSuite('AddressesProviderRegistry', (testEnv: TestEnv) => {
 
     const providersBefore = await registry.getAddressesProvidersList();
 
-    expect(
-      await registry.registerAddressesProvider(
+    await expect(
+      registry.registerAddressesProvider(
         NEW_ADDRESSES_PROVIDER_ADDRESS,
         NEW_ADDRESSES_PROVIDER_ID_2
       )
@@ -72,7 +72,7 @@ makeSuite('AddressesProviderRegistry', (testEnv: TestEnv) => {
     const { users, registry } = testEnv;
 
     // Simulating an addresses provider using the users[2] wallet address
-    expect(await registry.registerAddressesProvider(users[2].address, NEW_ADDRESSES_PROVIDER_ID_3))
+    await expect(registry.registerAddressesProvider(users[2].address, NEW_ADDRESSES_PROVIDER_ID_3))
       .to.emit(registry, 'AddressesProviderRegistered')
       .withArgs(users[2].address, NEW_ADDRESSES_PROVIDER_ID_3);
 
@@ -97,7 +97,7 @@ makeSuite('AddressesProviderRegistry', (testEnv: TestEnv) => {
       await registry.getAddressesProviderIdByAddress(NEW_ADDRESSES_PROVIDER_ADDRESS)
     ).to.be.equal(NEW_ADDRESSES_PROVIDER_ID_2);
 
-    expect(await registry.unregisterAddressesProvider(NEW_ADDRESSES_PROVIDER_ADDRESS))
+    await expect(registry.unregisterAddressesProvider(NEW_ADDRESSES_PROVIDER_ADDRESS))
       .to.emit(registry, 'AddressesProviderUnregistered')
       .withArgs(NEW_ADDRESSES_PROVIDER_ADDRESS, NEW_ADDRESSES_PROVIDER_ID_2);
 
@@ -177,8 +177,8 @@ makeSuite('AddressesProviderRegistry', (testEnv: TestEnv) => {
 
     const providersBefore = await registry.getAddressesProvidersList();
 
-    expect(
-      await registry.registerAddressesProvider(
+    await expect(
+      registry.registerAddressesProvider(
         NEW_ADDRESSES_PROVIDER_ADDRESS,
         NEW_ADDRESSES_PROVIDER_ID_2
       )
@@ -212,7 +212,7 @@ makeSuite('AddressesProviderRegistry', (testEnv: TestEnv) => {
     const providerToRemove = providersBefore[providersBefore.length - 1];
     const providerToRemoveId = await registry.getAddressesProviderIdByAddress(providerToRemove);
 
-    expect(await registry.unregisterAddressesProvider(providerToRemove))
+    await expect(registry.unregisterAddressesProvider(providerToRemove))
       .to.emit(registry, 'AddressesProviderUnregistered')
       .withArgs(providerToRemove, providerToRemoveId);
 

--- a/test-suites/atoken-delegation-aware.spec.ts
+++ b/test-suites/atoken-delegation-aware.spec.ts
@@ -38,7 +38,7 @@ makeSuite('AToken: DelegationAwareAToken', (testEnv: TestEnv) => {
   it('Delegates to user 2', async () => {
     const { users } = testEnv;
 
-    expect(await delegationAToken.delegateUnderlyingTo(users[2].address))
+    await expect(delegationAToken.delegateUnderlyingTo(users[2].address))
       .to.emit(delegationAToken, 'DelegateUnderlyingTo')
       .withArgs(users[2].address);
 

--- a/test-suites/atoken-edge.spec.ts
+++ b/test-suites/atoken-edge.spec.ts
@@ -71,7 +71,7 @@ makeSuite('AToken: Edge cases', (testEnv: TestEnv) => {
 
   it('approve() with a ZERO_ADDRESS spender', async () => {
     const { users, aDai } = testEnv;
-    expect(await aDai.connect(users[0].signer).approve(ZERO_ADDRESS, MAX_UINT_AMOUNT))
+    await expect(aDai.connect(users[0].signer).approve(ZERO_ADDRESS, MAX_UINT_AMOUNT))
       .to.emit(aDai, 'Approval')
       .withArgs(users[0].address, ZERO_ADDRESS, MAX_UINT_AMOUNT);
   });
@@ -105,14 +105,14 @@ makeSuite('AToken: Edge cases', (testEnv: TestEnv) => {
 
   it('transfer() with a ZERO_ADDRESS recipient', async () => {
     const { users, aDai } = testEnv;
-    expect(await aDai.connect(users[1].signer).transfer(ZERO_ADDRESS, 0))
+    await expect(aDai.connect(users[1].signer).transfer(ZERO_ADDRESS, 0))
       .to.emit(aDai, 'Transfer')
       .withArgs(users[1].address, ZERO_ADDRESS, 0);
   });
 
   it('transfer() with a ZERO_ADDRESS origin', async () => {
     const { users, aDai } = testEnv;
-    expect(await aDai.connect(users[1].signer).transferFrom(ZERO_ADDRESS, users[1].address, 0))
+    await expect(aDai.connect(users[1].signer).transferFrom(ZERO_ADDRESS, users[1].address, 0))
       .to.emit(aDai, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[1].address, 0);
   });
@@ -141,7 +141,7 @@ makeSuite('AToken: Edge cases', (testEnv: TestEnv) => {
     const poolSigner = await hre.ethers.getSigner(pool.address);
 
     const mintingAmount = await convertToCurrencyDecimals(aDai.address, '100');
-    expect(
+    await expect(
       aDai
         .connect(poolSigner)
         .mint(ZERO_ADDRESS, ZERO_ADDRESS, mintingAmount, utils.parseUnits('1', 27))
@@ -174,8 +174,8 @@ makeSuite('AToken: Edge cases', (testEnv: TestEnv) => {
     const poolSigner = await hre.ethers.getSigner(pool.address);
 
     const burnAmount = await convertToCurrencyDecimals(aDai.address, '100');
-    expect(
-      await aDai
+    await expect(
+      aDai
         .connect(poolSigner)
         .burn(ZERO_ADDRESS, users[0].address, burnAmount, utils.parseUnits('1', 27))
     )

--- a/test-suites/atoken-transfer.spec.ts
+++ b/test-suites/atoken-transfer.spec.ts
@@ -36,7 +36,7 @@ makeSuite('AToken: Transfer', (testEnv: TestEnv) => {
 
     expect(await aDai.getPreviousIndex(users[0].address)).to.be.gt(0);
 
-    expect(await aDai.connect(users[0].signer).transfer(users[0].address, amountDAItoDeposit))
+    await expect(aDai.connect(users[0].signer).transfer(users[0].address, amountDAItoDeposit))
       .to.emit(aDai, 'Transfer')
       .withArgs(users[0].address, users[0].address, amountDAItoDeposit);
 
@@ -71,7 +71,7 @@ makeSuite('AToken: Transfer', (testEnv: TestEnv) => {
 
     expect(await pool.connect(users[0].signer).setUserUseReserveAsCollateral(dai.address, false));
 
-    expect(await aDai.connect(users[0].signer).transfer(users[1].address, amountDAItoDeposit))
+    await expect(aDai.connect(users[0].signer).transfer(users[1].address, amountDAItoDeposit))
       .to.emit(aDai, 'Transfer')
       .withArgs(users[0].address, users[1].address, amountDAItoDeposit);
 
@@ -112,7 +112,7 @@ makeSuite('AToken: Transfer', (testEnv: TestEnv) => {
         .deposit(dai.address, amountDAItoDeposit, users[0].address, '0')
     );
 
-    expect(await aDai.connect(users[0].signer).transfer(users[1].address, amountDAItoTransfer))
+    await expect(aDai.connect(users[0].signer).transfer(users[1].address, amountDAItoTransfer))
       .to.emit(aDai, 'Transfer')
       .withArgs(users[0].address, users[1].address, amountDAItoTransfer);
     expect(await aDai.balanceOf(users[0].address)).to.be.eq(
@@ -124,7 +124,7 @@ makeSuite('AToken: Transfer', (testEnv: TestEnv) => {
       INVALID_TO_BALANCE_AFTER_TRANSFER
     );
 
-    expect(await aDai.connect(users[0].signer).transfer(users[1].address, amountDAItoTransfer))
+    await expect(aDai.connect(users[0].signer).transfer(users[1].address, amountDAItoTransfer))
       .to.emit(aDai, 'Transfer')
       .withArgs(users[0].address, users[1].address, amountDAItoTransfer);
     expect(await aDai.balanceOf(users[0].address)).to.be.eq(
@@ -136,7 +136,7 @@ makeSuite('AToken: Transfer', (testEnv: TestEnv) => {
       INVALID_TO_BALANCE_AFTER_TRANSFER
     );
 
-    expect(await aDai.connect(users[0].signer).transfer(users[1].address, 0))
+    await expect(aDai.connect(users[0].signer).transfer(users[1].address, 0))
       .to.emit(aDai, 'Transfer')
       .withArgs(users[0].address, users[1].address, 0);
     expect(await aDai.balanceOf(users[0].address)).to.be.eq(
@@ -168,7 +168,7 @@ makeSuite('AToken: Transfer', (testEnv: TestEnv) => {
         .deposit(dai.address, amountDAItoDeposit, users[0].address, '0')
     );
 
-    expect(await aDai.connect(users[0].signer).transfer(users[1].address, amountDAItoDeposit))
+    await expect(aDai.connect(users[0].signer).transfer(users[1].address, amountDAItoDeposit))
       .to.emit(aDai, 'Transfer')
       .withArgs(users[0].address, users[1].address, amountDAItoDeposit);
 
@@ -232,7 +232,7 @@ makeSuite('AToken: Transfer', (testEnv: TestEnv) => {
 
     const aDAItoTransfer = await convertToCurrencyDecimals(dai.address, '100');
 
-    expect(await aDai.connect(users[1].signer).transfer(users[0].address, aDAItoTransfer))
+    await expect(aDai.connect(users[1].signer).transfer(users[0].address, aDAItoTransfer))
       .to.emit(aDai, 'Transfer')
       .withArgs(users[1].address, users[0].address, aDAItoTransfer);
 

--- a/test-suites/configurator-borrow-cap.spec.ts
+++ b/test-suites/configurator-borrow-cap.spec.ts
@@ -121,10 +121,10 @@ makeSuite('PoolConfigurator: Borrow Cap', (testEnv: TestEnv) => {
     const { borrowCap: daiOldBorrowCap } = await helpersContract.getReserveCaps(dai.address);
 
     const newCap = 10;
-    expect(await configurator.setBorrowCap(usdc.address, newCap))
+    await expect(configurator.setBorrowCap(usdc.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(usdc.address, daiOldBorrowCap, newCap);
-    expect(await configurator.setBorrowCap(dai.address, newCap))
+    await expect(configurator.setBorrowCap(dai.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(dai.address, usdcOldBorrowCap, newCap);
 
@@ -179,10 +179,10 @@ makeSuite('PoolConfigurator: Borrow Cap', (testEnv: TestEnv) => {
     const { borrowCap: usdcOldBorrowCap } = await helpersContract.getReserveCaps(usdc.address);
     const { borrowCap: daiOldBorrowCap } = await helpersContract.getReserveCaps(dai.address);
 
-    expect(await configurator.setBorrowCap(usdc.address, newCap))
+    await expect(configurator.setBorrowCap(usdc.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(usdc.address, usdcOldBorrowCap, newCap);
-    expect(await configurator.setBorrowCap(dai.address, newCap))
+    await expect(configurator.setBorrowCap(dai.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(dai.address, daiOldBorrowCap, newCap);
 
@@ -224,7 +224,7 @@ makeSuite('PoolConfigurator: Borrow Cap', (testEnv: TestEnv) => {
     const { borrowCap: wethOldBorrowCap } = await helpersContract.getReserveCaps(weth.address);
 
     const newCap = 2;
-    expect(await configurator.setBorrowCap(weth.address, newCap))
+    await expect(configurator.setBorrowCap(weth.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(weth.address, wethOldBorrowCap, newCap);
 
@@ -307,10 +307,10 @@ makeSuite('PoolConfigurator: Borrow Cap', (testEnv: TestEnv) => {
     const { borrowCap: daiOldBorrowCap } = await helpersContract.getReserveCaps(dai.address);
 
     const newCap = '1000';
-    expect(await configurator.setBorrowCap(usdc.address, newCap))
+    await expect(configurator.setBorrowCap(usdc.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(usdc.address, usdcOldBorrowCap, newCap);
-    expect(await configurator.setBorrowCap(dai.address, newCap))
+    await expect(configurator.setBorrowCap(dai.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(dai.address, daiOldBorrowCap, newCap);
 
@@ -353,10 +353,10 @@ makeSuite('PoolConfigurator: Borrow Cap', (testEnv: TestEnv) => {
     const { borrowCap: daiOldBorrowCap } = await helpersContract.getReserveCaps(dai.address);
 
     const newCap = '200';
-    expect(await configurator.setBorrowCap(usdc.address, newCap))
+    await expect(configurator.setBorrowCap(usdc.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(usdc.address, usdcOldBorrowCap, newCap);
-    expect(await configurator.setBorrowCap(dai.address, newCap))
+    await expect(configurator.setBorrowCap(dai.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(dai.address, daiOldBorrowCap, newCap);
 
@@ -399,10 +399,10 @@ makeSuite('PoolConfigurator: Borrow Cap', (testEnv: TestEnv) => {
     const { borrowCap: daiOldBorrowCap } = await helpersContract.getReserveCaps(dai.address);
 
     const newCap = MAX_BORROW_CAP;
-    expect(await configurator.setBorrowCap(usdc.address, newCap))
+    await expect(configurator.setBorrowCap(usdc.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(usdc.address, usdcOldBorrowCap, newCap);
-    expect(await configurator.setBorrowCap(dai.address, newCap))
+    await expect(configurator.setBorrowCap(dai.address, newCap))
       .to.emit(configurator, 'BorrowCapChanged')
       .withArgs(dai.address, daiOldBorrowCap, newCap);
 

--- a/test-suites/configurator-liquidation-protocol-fee.spec.ts
+++ b/test-suites/configurator-liquidation-protocol-fee.spec.ts
@@ -44,10 +44,10 @@ makeSuite('PoolConfigurator: Liquidation Protocol Fee', (testEnv: TestEnv) => {
 
     const liquidationProtocolFee = 1000;
 
-    expect(await configurator.setLiquidationProtocolFee(usdc.address, liquidationProtocolFee))
+    await expect(configurator.setLiquidationProtocolFee(usdc.address, liquidationProtocolFee))
       .to.emit(configurator, 'LiquidationProtocolFeeChanged')
       .withArgs(usdc.address, oldUsdcLiquidationProtocolFee, liquidationProtocolFee);
-    expect(await configurator.setLiquidationProtocolFee(dai.address, liquidationProtocolFee))
+    await expect(configurator.setLiquidationProtocolFee(dai.address, liquidationProtocolFee))
       .to.emit(configurator, 'LiquidationProtocolFeeChanged')
       .withArgs(dai.address, oldDaiLiquidationProtocolFee, liquidationProtocolFee);
 
@@ -72,10 +72,10 @@ makeSuite('PoolConfigurator: Liquidation Protocol Fee', (testEnv: TestEnv) => {
 
     const liquidationProtocolFee = 10000;
 
-    expect(await configurator.setLiquidationProtocolFee(usdc.address, liquidationProtocolFee))
+    await expect(configurator.setLiquidationProtocolFee(usdc.address, liquidationProtocolFee))
       .to.emit(configurator, 'LiquidationProtocolFeeChanged')
       .withArgs(usdc.address, oldUsdcLiquidationProtocolFee, liquidationProtocolFee);
-    expect(await configurator.setLiquidationProtocolFee(dai.address, liquidationProtocolFee))
+    await expect(configurator.setLiquidationProtocolFee(dai.address, liquidationProtocolFee))
       .to.emit(configurator, 'LiquidationProtocolFeeChanged')
       .withArgs(dai.address, oldDaiLiquidationProtocolFee, liquidationProtocolFee);
 

--- a/test-suites/configurator-supply-cap.spec.ts
+++ b/test-suites/configurator-supply-cap.spec.ts
@@ -66,10 +66,10 @@ makeSuite('PoolConfigurator: Supply Cap', (testEnv: TestEnv) => {
 
     const newCap = '1000';
 
-    expect(await configurator.setSupplyCap(usdc.address, newCap))
+    await expect(configurator.setSupplyCap(usdc.address, newCap))
       .to.emit(configurator, 'SupplyCapChanged')
       .withArgs(usdc.address, oldUsdcSupplyCap, newCap);
-    expect(await configurator.setSupplyCap(dai.address, newCap))
+    await expect(configurator.setSupplyCap(dai.address, newCap))
       .to.emit(configurator, 'SupplyCapChanged')
       .withArgs(dai.address, oldDaiSupplyCap, newCap);
 
@@ -117,10 +117,10 @@ makeSuite('PoolConfigurator: Supply Cap', (testEnv: TestEnv) => {
     const { supplyCap: oldDaiSupplyCap } = await helpersContract.getReserveCaps(dai.address);
 
     const newCap = '1110';
-    expect(await configurator.setSupplyCap(usdc.address, newCap))
+    await expect(configurator.setSupplyCap(usdc.address, newCap))
       .to.emit(configurator, 'SupplyCapChanged')
       .withArgs(usdc.address, oldUsdcSupplyCap, newCap);
-    expect(await configurator.setSupplyCap(dai.address, newCap))
+    await expect(configurator.setSupplyCap(dai.address, newCap))
       .to.emit(configurator, 'SupplyCapChanged')
       .withArgs(dai.address, oldDaiSupplyCap, newCap);
 
@@ -234,10 +234,10 @@ makeSuite('PoolConfigurator: Supply Cap', (testEnv: TestEnv) => {
     const { supplyCap: oldDaiSupplyCap } = await helpersContract.getReserveCaps(dai.address);
 
     const newCap = '2000';
-    expect(await configurator.setSupplyCap(usdc.address, newCap))
+    await expect(configurator.setSupplyCap(usdc.address, newCap))
       .to.emit(configurator, 'SupplyCapChanged')
       .withArgs(usdc.address, oldUsdcSupplyCap, newCap);
-    expect(await configurator.setSupplyCap(dai.address, newCap))
+    await expect(configurator.setSupplyCap(dai.address, newCap))
       .to.emit(configurator, 'SupplyCapChanged')
       .withArgs(dai.address, oldDaiSupplyCap, newCap);
 
@@ -274,10 +274,10 @@ makeSuite('PoolConfigurator: Supply Cap', (testEnv: TestEnv) => {
     const { supplyCap: oldDaiSupplyCap } = await helpersContract.getReserveCaps(dai.address);
 
     const newCap = '1200';
-    expect(await configurator.setSupplyCap(usdc.address, newCap))
+    await expect(configurator.setSupplyCap(usdc.address, newCap))
       .to.emit(configurator, 'SupplyCapChanged')
       .withArgs(usdc.address, oldUsdcSupplyCap, newCap);
-    expect(await configurator.setSupplyCap(dai.address, newCap))
+    await expect(configurator.setSupplyCap(dai.address, newCap))
       .to.emit(configurator, 'SupplyCapChanged')
       .withArgs(dai.address, oldDaiSupplyCap, newCap);
 
@@ -319,10 +319,10 @@ makeSuite('PoolConfigurator: Supply Cap', (testEnv: TestEnv) => {
     const { supplyCap: oldDaiSupplyCap } = await helpersContract.getReserveCaps(dai.address);
 
     const newCap = MAX_SUPPLY_CAP;
-    expect(await configurator.setSupplyCap(usdc.address, newCap))
+    await expect(configurator.setSupplyCap(usdc.address, newCap))
       .to.emit(configurator, 'SupplyCapChanged')
       .withArgs(usdc.address, oldUsdcSupplyCap, newCap);
-    expect(await configurator.setSupplyCap(dai.address, newCap))
+    await expect(configurator.setSupplyCap(dai.address, newCap))
       .to.emit(configurator, 'SupplyCapChanged')
       .withArgs(dai.address, oldDaiSupplyCap, newCap);
 

--- a/test-suites/configurator.spec.ts
+++ b/test-suites/configurator.spec.ts
@@ -203,7 +203,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
 
   it('Pauses the ETH reserve by pool admin', async () => {
     const { configurator, weth, helpersContract } = testEnv;
-    expect(await configurator.setReservePause(weth.address, true))
+    await expect(configurator.setReservePause(weth.address, true))
       .to.emit(configurator, 'ReservePaused')
       .withArgs(weth.address, true);
 
@@ -215,7 +215,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
 
   it('Unpauses the ETH reserve by pool admin', async () => {
     const { configurator, helpersContract, weth } = testEnv;
-    expect(await configurator.setReservePause(weth.address, false))
+    await expect(configurator.setReservePause(weth.address, false))
       .to.emit(configurator, 'ReservePaused')
       .withArgs(weth.address, false);
 
@@ -224,7 +224,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
 
   it('Pauses the ETH reserve by emergency admin', async () => {
     const { configurator, weth, helpersContract, emergencyAdmin } = testEnv;
-    expect(await configurator.connect(emergencyAdmin.signer).setReservePause(weth.address, true))
+    await expect(configurator.connect(emergencyAdmin.signer).setReservePause(weth.address, true))
       .to.emit(configurator, 'ReservePaused')
       .withArgs(weth.address, true);
 
@@ -236,7 +236,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
 
   it('Unpauses the ETH reserve by emergency admin', async () => {
     const { configurator, helpersContract, weth, emergencyAdmin } = testEnv;
-    expect(await configurator.connect(emergencyAdmin.signer).setReservePause(weth.address, false))
+    await expect(configurator.connect(emergencyAdmin.signer).setReservePause(weth.address, false))
       .to.emit(configurator, 'ReservePaused')
       .withArgs(weth.address, false);
 
@@ -246,7 +246,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
   it('Freezes the ETH reserve by pool Admin', async () => {
     const { configurator, weth, helpersContract } = testEnv;
 
-    expect(await configurator.setReserveFreeze(weth.address, true))
+    await expect(configurator.setReserveFreeze(weth.address, true))
       .to.emit(configurator, 'ReserveFrozen')
       .withArgs(weth.address, true);
 
@@ -258,7 +258,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
 
   it('Unfreezes the ETH reserve by Pool admin', async () => {
     const { configurator, helpersContract, weth } = testEnv;
-    expect(await configurator.setReserveFreeze(weth.address, false))
+    await expect(configurator.setReserveFreeze(weth.address, false))
       .to.emit(configurator, 'ReserveFrozen')
       .withArgs(weth.address, false);
 
@@ -267,7 +267,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
 
   it('Freezes the ETH reserve by Risk Admin', async () => {
     const { configurator, weth, helpersContract, riskAdmin } = testEnv;
-    expect(await configurator.connect(riskAdmin.signer).setReserveFreeze(weth.address, true))
+    await expect(configurator.connect(riskAdmin.signer).setReserveFreeze(weth.address, true))
       .to.emit(configurator, 'ReserveFrozen')
       .withArgs(weth.address, true);
 
@@ -279,7 +279,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
 
   it('Unfreezes the ETH reserve by Risk admin', async () => {
     const { configurator, helpersContract, weth, riskAdmin } = testEnv;
-    expect(await configurator.connect(riskAdmin.signer).setReserveFreeze(weth.address, false))
+    await expect(configurator.connect(riskAdmin.signer).setReserveFreeze(weth.address, false))
       .to.emit(configurator, 'ReserveFrozen')
       .withArgs(weth.address, false);
 
@@ -311,7 +311,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
   it('Disable stable borrow rate on the ETH reserve via pool admin', async () => {
     const snap = await evmSnapshot();
     const { configurator, helpersContract, weth } = testEnv;
-    expect(await configurator.setReserveStableRateBorrowing(weth.address, false))
+    await expect(configurator.setReserveStableRateBorrowing(weth.address, false))
       .to.emit(configurator, 'ReserveStableRateBorrowing')
       .withArgs(weth.address, false);
 
@@ -324,10 +324,8 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
 
   it('Disable stable borrow rate on the ETH reserve via risk admin', async () => {
     const { configurator, helpersContract, weth, riskAdmin } = testEnv;
-    expect(
-      await configurator
-        .connect(riskAdmin.signer)
-        .setReserveStableRateBorrowing(weth.address, false)
+    await expect(
+      configurator.connect(riskAdmin.signer).setReserveStableRateBorrowing(weth.address, false)
     )
       .to.emit(configurator, 'ReserveStableRateBorrowing')
       .withArgs(weth.address, false);
@@ -341,7 +339,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
   it('Deactivates the ETH reserve for borrowing via pool admin', async () => {
     const snap = await evmSnapshot();
     const { configurator, helpersContract, weth } = testEnv;
-    expect(await configurator.setReserveBorrowing(weth.address, false))
+    await expect(configurator.setReserveBorrowing(weth.address, false))
       .to.emit(configurator, 'ReserveBorrowing')
       .withArgs(weth.address, false);
 
@@ -355,7 +353,7 @@ makeSuite('PoolConfigurator', (testEnv: TestEnv) => {
 
   it('Deactivates the ETH reserve for borrowing via risk admin', async () => {
     const { configurator, helpersContract, weth, riskAdmin } = testEnv;
-    expect(await configurator.connect(riskAdmin.signer).setReserveBorrowing(weth.address, false))
+    await expect(configurator.connect(riskAdmin.signer).setReserveBorrowing(weth.address, false))
       .to.emit(configurator, 'ReserveBorrowing')
       .withArgs(weth.address, false);
 

--- a/test-suites/pausable-pool.spec.ts
+++ b/test-suites/pausable-pool.spec.ts
@@ -366,18 +366,18 @@ makeSuite('PausablePool', (testEnv: TestEnv) => {
     const aclManager = await (
       await new ACLManager__factory(await getFirstSigner()).deploy(poolAddressesProvider.address)
     ).deployed();
-    expect(await poolAddressesProvider.setACLManager(aclManager.address))
+    await expect(poolAddressesProvider.setACLManager(aclManager.address))
       .to.emit(poolAddressesProvider, 'ACLManagerUpdated')
       .withArgs(ZERO_ADDRESS, aclManager.address);
 
     // Set role of EmergencyAdmin
     const emergencyAdminRole = await aclManager.EMERGENCY_ADMIN_ROLE();
-    expect(await aclManager.addEmergencyAdmin(emergencyAdmin.address))
+    await expect(aclManager.addEmergencyAdmin(emergencyAdmin.address))
       .to.emit(aclManager, 'RoleGranted')
       .withArgs(emergencyAdminRole, emergencyAdmin.address, poolAdmin.address);
 
     // Update the Pool impl with a MockPool
-    expect(await poolAddressesProvider.setPoolImpl(mockPool.address))
+    await expect(poolAddressesProvider.setPoolImpl(mockPool.address))
       .to.emit(poolAddressesProvider, 'PoolUpdated')
       .withArgs(ZERO_ADDRESS, mockPool.address);
 
@@ -387,7 +387,8 @@ makeSuite('PausablePool', (testEnv: TestEnv) => {
     expect(await proxiedMockPool.addReserveToReservesList(ZERO_ADDRESS));
 
     // Update the PoolConfigurator impl with the PoolConfigurator
-    expect(await poolAddressesProvider.setPoolConfiguratorImpl(poolConfigurator.address))
+    await expect(poolAddressesProvider.setPoolConfiguratorImpl(poolConfigurator.address));
+    await expect(poolAddressesProvider.setPoolConfiguratorImpl(poolConfigurator.address))
       .to.emit(poolAddressesProvider, 'PoolConfiguratorUpdated')
       .withArgs(ZERO_ADDRESS, poolConfigurator.address);
 

--- a/test-suites/pausable-pool.spec.ts
+++ b/test-suites/pausable-pool.spec.ts
@@ -387,7 +387,6 @@ makeSuite('PausablePool', (testEnv: TestEnv) => {
     expect(await proxiedMockPool.addReserveToReservesList(ZERO_ADDRESS));
 
     // Update the PoolConfigurator impl with the PoolConfigurator
-    await expect(poolAddressesProvider.setPoolConfiguratorImpl(poolConfigurator.address));
     await expect(poolAddressesProvider.setPoolConfiguratorImpl(poolConfigurator.address))
       .to.emit(poolAddressesProvider, 'PoolConfiguratorUpdated')
       .withArgs(ZERO_ADDRESS, poolConfigurator.address);

--- a/test-suites/pool-addresses-provider.spec.ts
+++ b/test-suites/pool-addresses-provider.spec.ts
@@ -58,8 +58,8 @@ makeSuite('PoolAddressesProvider', (testEnv: TestEnv) => {
     const mockPool = await deployPool();
     const proxiedAddressId = utils.formatBytes32String('RANDOM_PROXIED');
 
-    expect(
-      await addressesProvider
+    await expect(
+      addressesProvider
         .connect(currentAddressesProviderOwner.signer)
         .setAddressAsProxy(proxiedAddressId, mockPool.address)
     )
@@ -79,8 +79,8 @@ makeSuite('PoolAddressesProvider', (testEnv: TestEnv) => {
     const nonProxiedAddressId = utils.formatBytes32String('RANDOM_NON_PROXIED');
 
     const oldAddress = await addressesProvider.getAddress(nonProxiedAddressId);
-    expect(
-      await addressesProvider
+    await expect(
+      addressesProvider
         .connect(currentAddressesProviderOwner.signer)
         .setAddress(nonProxiedAddressId, mockNonProxiedAddress)
     )
@@ -108,8 +108,8 @@ makeSuite('PoolAddressesProvider', (testEnv: TestEnv) => {
     const oldNonProxiedAddress = await addressesProvider.getAddress(convertibleAddressId);
 
     // Add address as non proxy
-    expect(
-      await addressesProvider
+    await expect(
+      addressesProvider
         .connect(currentAddressesProviderOwner.signer)
         .setAddress(convertibleAddressId, mockConvertibleAddress)
     )
@@ -122,8 +122,8 @@ makeSuite('PoolAddressesProvider', (testEnv: TestEnv) => {
       .reverted;
 
     // Unregister address as non proxy
-    expect(
-      await addressesProvider
+    await expect(
+      addressesProvider
         .connect(currentAddressesProviderOwner.signer)
         .setAddress(convertibleAddressId, ZERO_ADDRESS)
     )
@@ -131,8 +131,8 @@ makeSuite('PoolAddressesProvider', (testEnv: TestEnv) => {
       .withArgs(convertibleAddressId, mockConvertibleAddress, ZERO_ADDRESS);
 
     // Add address as proxy
-    expect(
-      await addressesProvider
+    await expect(
+      addressesProvider
         .connect(currentAddressesProviderOwner.signer)
         .setAddressAsProxy(convertibleAddressId, mockConvertibleAddress)
     )

--- a/test-suites/pool-authorized-flashloan.spec.ts
+++ b/test-suites/pool-authorized-flashloan.spec.ts
@@ -28,7 +28,7 @@ makeSuite('Pool: Authorized FlashLoan', (testEnv: TestEnv) => {
   it('Authorize a flash borrower', async () => {
     const { deployer, aclManager } = testEnv;
     const flashBorrowerRole = await aclManager.FLASH_BORROWER_ROLE();
-    expect(await aclManager.addFlashBorrower(deployer.address))
+    await expect(aclManager.addFlashBorrower(deployer.address))
       .to.emit(aclManager, 'RoleGranted')
       .withArgs(flashBorrowerRole, deployer.address, deployer.address);
   });

--- a/test-suites/pool-edge.spec.ts
+++ b/test-suites/pool-edge.spec.ts
@@ -158,8 +158,8 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
     const oldPoolImpl = await getProxyImplementation(addressesProvider.address, poolProxyAddress);
 
     // Upgrade the Pool
-    expect(
-      await addressesProvider.connect(poolAdmin.signer).setPoolImpl(NEW_POOL_IMPL_ARTIFACT.address)
+    await expect(
+      addressesProvider.connect(poolAdmin.signer).setPoolImpl(NEW_POOL_IMPL_ARTIFACT.address)
     )
       .to.emit(addressesProvider, 'PoolUpdated')
       .withArgs(oldPoolImpl, NEW_POOL_IMPL_ARTIFACT.address);
@@ -303,7 +303,7 @@ makeSuite('Pool: Edge cases', (testEnv: TestEnv) => {
     expect(await pool.connect(user0.signer).supply(dai.address, amount, user0.address, 0));
 
     // Disable asset as collateral
-    expect(await pool.connect(user0.signer).setUserUseReserveAsCollateral(dai.address, false))
+    await expect(pool.connect(user0.signer).setUserUseReserveAsCollateral(dai.address, false))
       .to.emit(pool, 'ReserveUsedAsCollateralDisabled')
       .withArgs(dai.address, user0.address);
 

--- a/test-suites/pool-flashloan.spec.ts
+++ b/test-suites/pool-flashloan.spec.ts
@@ -236,8 +236,8 @@ makeSuite('Pool: FlashLoan', (testEnv: TestEnv) => {
 
     const reservesBefore = await aWETH.balanceOf(await aWETH.RESERVE_TREASURY_ADDRESS());
 
-    expect(
-      await pool.flashLoan(
+    await expect(
+      pool.flashLoan(
         _mockFlashLoanReceiver.address,
         [weth.address],
         [flashBorrowedAmount],
@@ -301,7 +301,7 @@ makeSuite('Pool: FlashLoan', (testEnv: TestEnv) => {
       )
     ).to.be.revertedWith(FLASHLOAN_DISABLED);
 
-    expect(await configurator.setReserveFlashLoaning(weth.address, true))
+    await expect(configurator.setReserveFlashLoaning(weth.address, true))
       .to.emit(configurator, 'ReserveFlashLoaning')
       .withArgs(weth.address, true);
 
@@ -394,8 +394,8 @@ makeSuite('Pool: FlashLoan', (testEnv: TestEnv) => {
 
     const borrowAmount = ethers.utils.parseEther('0.0571');
 
-    expect(
-      await pool
+    await expect(
+      pool
         .connect(caller.signer)
         .flashLoan(
           _mockFlashLoanReceiver.address,
@@ -692,8 +692,8 @@ makeSuite('Pool: FlashLoan', (testEnv: TestEnv) => {
 
     await _mockFlashLoanReceiver.setFailExecutionTransfer(true);
 
-    expect(
-      await pool
+    await expect(
+      pool
         .connect(caller.signer)
         .flashLoan(
           _mockFlashLoanReceiver.address,

--- a/test-suites/pool-l2.spec.ts
+++ b/test-suites/pool-l2.spec.ts
@@ -82,8 +82,8 @@ makeSuite('Pool: L2 functions', (testEnv: TestEnv) => {
     const oldPoolImpl = await getProxyImplementation(addressesProvider.address, poolProxyAddress);
 
     // Upgrade the Pool
-    expect(
-      await addressesProvider.connect(poolAdmin.signer).setPoolImpl(L2POOL_IMPL_ARTIFACT.address)
+    await expect(
+      addressesProvider.connect(poolAdmin.signer).setPoolImpl(L2POOL_IMPL_ARTIFACT.address)
     )
       .to.emit(addressesProvider, 'PoolUpdated')
       .withArgs(oldPoolImpl, L2POOL_IMPL_ARTIFACT.address);
@@ -114,7 +114,7 @@ makeSuite('Pool: L2 functions', (testEnv: TestEnv) => {
 
     const encoded = await encoder.encodeSupplyParams(dai.address, amount, referralCode);
 
-    expect(await l2Pool.connect(user0.signer)['supply(bytes32)'](encoded))
+    await expect(l2Pool.connect(user0.signer)['supply(bytes32)'](encoded))
       .to.emit(l2Pool, 'Supply')
       .withArgs(dai.address, user0.address, user0.address, amount, referralCode);
 
@@ -157,10 +157,8 @@ makeSuite('Pool: L2 functions', (testEnv: TestEnv) => {
       s
     );
 
-    expect(
-      await l2Pool
-        .connect(deployer.signer)
-        ['supplyWithPermit(bytes32,bytes32,bytes32)'](encoded[0], r, s)
+    await expect(
+      l2Pool.connect(deployer.signer)['supplyWithPermit(bytes32,bytes32,bytes32)'](encoded[0], r, s)
     )
       .to.emit(l2Pool, 'Supply')
       .withArgs(dai.address, deployer.address, deployer.address, amount, referralCode);
@@ -178,7 +176,7 @@ makeSuite('Pool: L2 functions', (testEnv: TestEnv) => {
     } = testEnv;
 
     const encoded = await encoder.encodeSetUserUseReserveAsCollateral(dai.address, false);
-    expect(await l2Pool.connect(user0.signer)['setUserUseReserveAsCollateral(bytes32)'](encoded))
+    await expect(l2Pool.connect(user0.signer)['setUserUseReserveAsCollateral(bytes32)'](encoded))
       .to.emit(l2Pool, 'ReserveUsedAsCollateralDisabled')
       .withArgs(dai.address, user0.address);
 

--- a/test-suites/price-oracle-sentinel.spec.ts
+++ b/test-suites/price-oracle-sentinel.spec.ts
@@ -60,8 +60,8 @@ makeSuite('PriceOracleSentinel', (testEnv: TestEnv) => {
   it('Admin sets a PriceOracleSentinel and activate it for DAI and WETH', async () => {
     const { addressesProvider, poolAdmin } = testEnv;
 
-    expect(
-      await addressesProvider
+    await expect(
+      addressesProvider
         .connect(poolAdmin.signer)
         .setPriceOracleSentinel(priceOracleSentinel.address)
     )
@@ -81,7 +81,7 @@ makeSuite('PriceOracleSentinel', (testEnv: TestEnv) => {
     const newGracePeriod = 0;
 
     expect(await priceOracleSentinel.getGracePeriod()).to.be.eq(GRACE_PERIOD);
-    expect(await priceOracleSentinel.connect(poolAdmin.signer).setGracePeriod(0))
+    await expect(priceOracleSentinel.connect(poolAdmin.signer).setGracePeriod(0))
       .to.emit(priceOracleSentinel, 'GracePeriodUpdated')
       .withArgs(0);
     expect(await priceOracleSentinel.getGracePeriod()).to.be.eq(newGracePeriod);
@@ -91,7 +91,7 @@ makeSuite('PriceOracleSentinel', (testEnv: TestEnv) => {
     const { riskAdmin } = testEnv;
 
     expect(await priceOracleSentinel.getGracePeriod()).to.be.eq(0);
-    expect(await priceOracleSentinel.connect(riskAdmin.signer).setGracePeriod(GRACE_PERIOD))
+    await expect(priceOracleSentinel.connect(riskAdmin.signer).setGracePeriod(GRACE_PERIOD))
       .to.emit(priceOracleSentinel, 'GracePeriodUpdated')
       .withArgs(GRACE_PERIOD);
     expect(await priceOracleSentinel.getGracePeriod()).to.be.eq(GRACE_PERIOD);
@@ -115,17 +115,15 @@ makeSuite('PriceOracleSentinel', (testEnv: TestEnv) => {
     const newSequencerOracle = ZERO_ADDRESS;
 
     expect(await priceOracleSentinel.getSequencerOracle()).to.be.eq(sequencerOracle.address);
-    expect(
-      await priceOracleSentinel.connect(poolAdmin.signer).setSequencerOracle(newSequencerOracle)
+    await expect(
+      priceOracleSentinel.connect(poolAdmin.signer).setSequencerOracle(newSequencerOracle)
     )
       .to.emit(priceOracleSentinel, 'SequencerOracleUpdated')
       .withArgs(newSequencerOracle);
     expect(await priceOracleSentinel.getSequencerOracle()).to.be.eq(newSequencerOracle);
 
-    expect(
-      await priceOracleSentinel
-        .connect(poolAdmin.signer)
-        .setSequencerOracle(sequencerOracle.address)
+    await expect(
+      priceOracleSentinel.connect(poolAdmin.signer).setSequencerOracle(sequencerOracle.address)
     )
       .to.emit(priceOracleSentinel, 'SequencerOracleUpdated')
       .withArgs(sequencerOracle.address);


### PR DESCRIPTION
- `await expect(sth).to.emit(sth).withArgs(lol)` will evaluate and throw
- `expect(await sth).to.emit(sth).withArgs(lol)` will always pass

Therefore this pr refactors the test-suite to always use the first.