### PR TITLE
fix: dont commuicate wrong flash premium

### DIFF
--- a/contracts/protocol/libraries/logic/FlashLoanLogic.sol
+++ b/contracts/protocol/libraries/logic/FlashLoanLogic.sol
@@ -91,9 +91,8 @@ library FlashLoanLogic {
 
     for (vars.i = 0; vars.i < params.assets.length; vars.i++) {
       vars.currentAmount = params.amounts[vars.i];
-      bool requirePremium = DataTypes.InterestRateMode(params.interestRateModes[vars.i]) ==
-        DataTypes.InterestRateMode.NONE;
-      vars.totalPremiums[vars.i] = requirePremium
+      vars.totalPremiums[vars.i] = DataTypes.InterestRateMode(params.interestRateModes[vars.i]) ==
+        DataTypes.InterestRateMode.NONE
         ? vars.currentAmount.percentMul(vars.flashloanPremiumTotal)
         : 0;
       IAToken(reservesData[params.assets[vars.i]].aTokenAddress).transferUnderlyingTo(

--- a/contracts/protocol/libraries/logic/FlashLoanLogic.sol
+++ b/contracts/protocol/libraries/logic/FlashLoanLogic.sol
@@ -91,7 +91,11 @@ library FlashLoanLogic {
 
     for (vars.i = 0; vars.i < params.assets.length; vars.i++) {
       vars.currentAmount = params.amounts[vars.i];
-      vars.totalPremiums[vars.i] = vars.currentAmount.percentMul(vars.flashloanPremiumTotal);
+      bool requirePremium = DataTypes.InterestRateMode(params.interestRateModes[vars.i]) ==
+        DataTypes.InterestRateMode.NONE;
+      vars.totalPremiums[vars.i] = requirePremium
+        ? vars.currentAmount.percentMul(vars.flashloanPremiumTotal)
+        : 0;
       IAToken(reservesData[params.assets[vars.i]].aTokenAddress).transferUnderlyingTo(
         params.receiverAddress,
         vars.currentAmount

--- a/test-suites/pool-flashloan.spec.ts
+++ b/test-suites/pool-flashloan.spec.ts
@@ -1,3 +1,4 @@
+import '@nomicfoundation/hardhat-chai-matchers';
 import { deployDefaultReserveInterestRateStrategy } from '@aave/deploy-v3/dist/helpers/contract-deployments';
 import { expect } from 'chai';
 import { BigNumber, ethers, Event, utils } from 'ethers';
@@ -176,7 +177,7 @@ makeSuite('Pool: FlashLoan', (testEnv: TestEnv) => {
     }
   });
 
-  it('Takes an authorized AAVE flash loan with mode = 0, returns the funds correctly', async () => {
+  it('Takes an authorized AAVE flash loan with mode = 0, returns the funds correctly, premium should be 0', async () => {
     const {
       pool,
       helpersContract,
@@ -194,17 +195,21 @@ makeSuite('Pool: FlashLoan', (testEnv: TestEnv) => {
 
     const totalLiquidityBefore = reserveData.totalAToken;
 
-    await pool
-      .connect(authorizedUser.signer)
-      .flashLoan(
-        _mockFlashLoanReceiver.address,
-        [aave.address],
-        [flashBorrowedAmount],
-        [0],
-        _mockFlashLoanReceiver.address,
-        '0x10',
-        '0'
-      );
+    await expect(
+      pool
+        .connect(authorizedUser.signer)
+        .flashLoan(
+          _mockFlashLoanReceiver.address,
+          [aave.address],
+          [flashBorrowedAmount],
+          [0],
+          _mockFlashLoanReceiver.address,
+          '0x10',
+          '0'
+        )
+    )
+      .to.emit(_mockFlashLoanReceiver, 'ExecutedWithSuccess')
+      .withArgs([aave.address], [flashBorrowedAmount], [0]);
 
     await pool.mintToTreasury([aave.address]);
 
@@ -570,7 +575,7 @@ makeSuite('Pool: FlashLoan', (testEnv: TestEnv) => {
     ).to.be.revertedWith(COLLATERAL_BALANCE_IS_ZERO);
   });
 
-  it('Caller deposits 5 WETH as collateral, Takes a USDC flashloan with mode = 2, does not return the funds. A loan for caller is created', async () => {
+  it('Caller deposits 5 WETH as collateral, Takes a USDC flashloan with mode = 2, does not return the funds. A loan for caller is created, premium should be 0', async () => {
     const { usdc, pool, weth, users, helpersContract } = testEnv;
 
     const caller = users[2];
@@ -585,21 +590,26 @@ makeSuite('Pool: FlashLoan', (testEnv: TestEnv) => {
 
     await pool.connect(caller.signer).deposit(weth.address, amountToDeposit, caller.address, '0');
 
-    await _mockFlashLoanReceiver.setFailExecutionTransfer(true);
-
     const flashloanAmount = await convertToCurrencyDecimals(usdc.address, '500');
 
-    await pool
-      .connect(caller.signer)
-      .flashLoan(
-        _mockFlashLoanReceiver.address,
-        [usdc.address],
-        [flashloanAmount],
-        [2],
-        caller.address,
-        '0x10',
-        '0'
-      );
+    await _mockFlashLoanReceiver.setFailExecutionTransfer(false);
+
+    await expect(
+      pool
+        .connect(caller.signer)
+        .flashLoan(
+          _mockFlashLoanReceiver.address,
+          [usdc.address],
+          [flashloanAmount],
+          [2],
+          caller.address,
+          '0x10',
+          '0'
+        )
+    )
+      .to.emit(_mockFlashLoanReceiver, 'ExecutedWithSuccess')
+      .withArgs([usdc.address], [flashloanAmount], [0]);
+
     const { variableDebtTokenAddress } = await helpersContract.getReserveTokensAddresses(
       usdc.address
     );

--- a/test-suites/pool-flashloan.spec.ts
+++ b/test-suites/pool-flashloan.spec.ts
@@ -1,4 +1,3 @@
-import '@nomicfoundation/hardhat-chai-matchers';
 import { deployDefaultReserveInterestRateStrategy } from '@aave/deploy-v3/dist/helpers/contract-deployments';
 import { expect } from 'chai';
 import { BigNumber, ethers, Event, utils } from 'ethers';


### PR DESCRIPTION
- fix: don't require flashloan premium when premium is zero
  - currently there are two cases in which flashloan premium is zero (being flashborrower & using mode != 0) - in the case of mode != 0, currently the receiver would receive `flashLoanPremium != 0` which will not be required to return. With the applied fix the premium will be correctly passed as `0`