### PR TITLE
Update inconsistent comment

### DIFF
--- a/contracts/protocol/libraries/logic/ReserveLogic.sol
+++ b/contracts/protocol/libraries/logic/ReserveLogic.sol
@@ -278,7 +278,7 @@ library ReserveLogic {
   }
 
   /**
-   * @notice Updates the reserve indexes and the timestamp of the update.
+   * @notice Updates the reserve indexes.
    * @param reserve The reserve reserve to be updated
    * @param reserveCache The cache layer holding the cached protocol data
    */


### PR DESCRIPTION
reserve timestamp isn't updated in `_updateIndexes`, instead it's updated in line 107 after `_accureToTreasury`