### PR TITLE
fix: remove default initialize

### DIFF
--- a/contracts/protocol/pool/Pool.sol
+++ b/contracts/protocol/pool/Pool.sol
@@ -109,8 +109,6 @@ contract Pool is VersionedInitializable, PoolStorage, IPool {
   function initialize(IPoolAddressesProvider provider) external virtual initializer {
     require(provider == ADDRESSES_PROVIDER, Errors.INVALID_ADDRESSES_PROVIDER);
     _maxStableRateBorrowSizePercent = 0.25e4;
-    _flashLoanPremiumTotal = 0.0009e4;
-    _flashLoanPremiumToProtocol = 0;
   }
 
   /// @inheritdoc IPool


### PR DESCRIPTION
It doesn't really make sense to initialize here with 9 and 0, and then in deploy script update it via common config to 5 and 4.
Generally it doesn't make to much sense to initialize potentially changing values in initialize as potentially every upgrade will reset them. Probably better to initialize as 0 and set them as part of the deploy pipeline (in fact that's already done for these two values).