### PR TITLE
Reduce repeated checks in the SupplyLogic.sol

### DIFF
--- a/contracts/protocol/libraries/logic/SupplyLogic.sol
+++ b/contracts/protocol/libraries/logic/SupplyLogic.sol
@@ -122,18 +122,20 @@ library SupplyLogic {
 
     if (params.amount == type(uint256).max) {
       amountToWithdraw = userBalance;
+      
+      bool isCollateral = userConfig.isUsingAsCollateral(reserve.id);
+
+      if (isCollateral) {
+        userConfig.setUsingAsCollateral(reserve.id, false);
+        emit ReserveUsedAsCollateralDisabled(params.asset, msg.sender);
+      }
     }
 
     ValidationLogic.validateWithdraw(reserveCache, amountToWithdraw, userBalance);
 
     reserve.updateInterestRates(reserveCache, params.asset, 0, amountToWithdraw);
 
-    bool isCollateral = userConfig.isUsingAsCollateral(reserve.id);
 
-    if (isCollateral && amountToWithdraw == userBalance) {
-      userConfig.setUsingAsCollateral(reserve.id, false);
-      emit ReserveUsedAsCollateralDisabled(params.asset, msg.sender);
-    }
 
     IAToken(reserveCache.aTokenAddress).burn(
       msg.sender,


### PR DESCRIPTION
Merge two `if` branches into a two-level `if` branches to save gas without changing the logic.

The only case in this PR not covered is when the passed-in parameter `params.amount` equal to userBalance that is `IAToken(reserveCache.aTokenAddress).scaledBalanceOf(msg.sender).rayMul(reserveCache.nextLiquidityIndex);`

This pr is ok if only the value `type(uint256).max` stands for withdraw all asset.