### PR TITLE
Fix pragma in FlashLoanSimpleReceiverBase.sol

### DIFF
--- a/contracts/flashloan/base/FlashLoanSimpleReceiverBase.sol
+++ b/contracts/flashloan/base/FlashLoanSimpleReceiverBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IFlashLoanSimpleReceiver} from '../interfaces/IFlashLoanSimpleReceiver.sol';
 import {IPoolAddressesProvider} from '../../interfaces/IPoolAddressesProvider.sol';


### PR DESCRIPTION
Typo in pragma only allowing version 0.8.10