### PR TITLE
feat: add MutliCall

### DIFF
--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -218,6 +218,21 @@ interface IPool {
    * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
    *   0 if the action is executed directly by the user, without any middle-man
    */
+
+  enum MultiCallAction {
+    Supply,
+    Borrow,
+    Repay,
+    Withdraw,
+    SetUserUseReserveAsCollateral,
+    SwapBorrowRateMode,
+    RebalanceStableBorrowRate,
+    SupplyWithPermit,
+    RepayWithPermit,
+    RepayWithATokens,
+    LiquidationCall
+  }
+
   function mintUnbacked(
     address asset,
     uint256 amount,
@@ -463,6 +478,14 @@ interface IPool {
     bytes calldata params,
     uint16 referralCode
   ) external;
+
+  /**
+   * @notice Allows to batch call any user relevant functions in a single transaction,
+   * any revert in any of the actions being executed, will result in a revert of the batch
+   * @param actions includes the set of MultiCallAction that a user is able to execute
+   * @param params Array of encoded MultiCallAction parameters
+   */
+  function multiCall(bytes calldata actions, bytes[] calldata params) external;
 
   /**
    * @notice Returns the user account data across all the reserves

--- a/contracts/protocol/libraries/types/Calldata.sol
+++ b/contracts/protocol/libraries/types/Calldata.sol
@@ -1,39 +1,45 @@
 pragma solidity ^0.8.0;
 
 library Calldata {
-  function getAddress(bytes calldata self, bytes1 pos) internal pure returns (address output) {
+  function getAddress(bytes calldata self) internal pure returns (address output) {
     assembly {
-      output := calldataload(add(self.offset, pos))
+      output := calldataload(self.offset)
     }
   }
 
-  function getUint256(bytes calldata self, bytes1 pos) internal pure returns (uint output) {
+  function getAddress(bytes calldata self, bytes1 offset) internal pure returns (address output) {
     assembly {
-      output := calldataload(add(self.offset, pos))
+      output := calldataload(add(self.offset, offset))
     }
   }
 
-  function getUint16(bytes calldata self, bytes1 pos) internal pure returns (uint16 output) {
+  function getUint256(bytes calldata self, bytes1 offset) internal pure returns (uint output) {
     assembly {
-      output := calldataload(add(self.offset, pos))
+      output := calldataload(add(self.offset, offset))
     }
   }
 
-  function getUint8(bytes calldata self, bytes1 pos) internal pure returns (uint8 output) {
+  function getUint16(bytes calldata self, bytes1 offset) internal pure returns (uint16 output) {
     assembly {
-      output := calldataload(add(self.offset, pos))
+      output := calldataload(add(self.offset, offset))
     }
   }
 
-  function getBool(bytes calldata self, bytes1 pos) internal pure returns (bool output) {
+  function getUint8(bytes calldata self, bytes1 offset) internal pure returns (uint8 output) {
     assembly {
-      output := calldataload(add(self.offset, pos))
+      output := calldataload(add(self.offset, offset))
     }
   }
 
-  function getBytes32(bytes calldata self, bytes1 pos) internal pure returns (bytes32 output) {
+  function getBool(bytes calldata self, bytes1 offset) internal pure returns (bool output) {
     assembly {
-      output := calldataload(add(self.offset, pos))
+      output := calldataload(add(self.offset, offset))
+    }
+  }
+
+  function getBytes32(bytes calldata self, bytes1 offset) internal pure returns (bytes32 output) {
+    assembly {
+      output := calldataload(add(self.offset, offset))
     }
   }
 }

--- a/contracts/protocol/libraries/types/Calldata.sol
+++ b/contracts/protocol/libraries/types/Calldata.sol
@@ -7,39 +7,39 @@ library Calldata {
     }
   }
 
-  function getAddress(bytes calldata self, bytes1 offset) internal pure returns (address output) {
+  function getAddress(bytes calldata self, uint8 index) internal pure returns (address output) {
     assembly {
-      output := calldataload(add(self.offset, offset))
+      output := calldataload(add(self.offset, mul(index, 0x20)))
     }
   }
 
-  function getUint256(bytes calldata self, bytes1 offset) internal pure returns (uint output) {
+  function getUint256(bytes calldata self, uint8 index) internal pure returns (uint output) {
     assembly {
-      output := calldataload(add(self.offset, offset))
+      output := calldataload(add(self.offset, mul(index, 0x20)))
     }
   }
 
-  function getUint16(bytes calldata self, bytes1 offset) internal pure returns (uint16 output) {
+  function getUint16(bytes calldata self, uint8 index) internal pure returns (uint16 output) {
     assembly {
-      output := calldataload(add(self.offset, offset))
+      output := calldataload(add(self.offset, mul(index, 0x20)))
     }
   }
 
-  function getUint8(bytes calldata self, bytes1 offset) internal pure returns (uint8 output) {
+  function getUint8(bytes calldata self, uint8 index) internal pure returns (uint8 output) {
     assembly {
-      output := calldataload(add(self.offset, offset))
+      output := calldataload(add(self.offset, mul(index, 0x20)))
     }
   }
 
-  function getBool(bytes calldata self, bytes1 offset) internal pure returns (bool output) {
+  function getBool(bytes calldata self, uint8 index) internal pure returns (bool output) {
     assembly {
-      output := calldataload(add(self.offset, offset))
+      output := calldataload(add(self.offset, mul(index, 0x20)))
     }
   }
 
-  function getBytes32(bytes calldata self, bytes1 offset) internal pure returns (bytes32 output) {
+  function getBytes32(bytes calldata self, uint8 index) internal pure returns (bytes32 output) {
     assembly {
-      output := calldataload(add(self.offset, offset))
+      output := calldataload(add(self.offset, mul(index, 0x20)))
     }
   }
 }

--- a/contracts/protocol/libraries/types/Calldata.sol
+++ b/contracts/protocol/libraries/types/Calldata.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.8.0;
+
+library Calldata {
+  function getAddress(bytes calldata self, bytes1 pos) internal pure returns (address output) {
+    assembly {
+      output := calldataload(add(self.offset, pos))
+    }
+  }
+
+  function getUint256(bytes calldata self, bytes1 pos) internal pure returns (uint output) {
+    assembly {
+      output := calldataload(add(self.offset, pos))
+    }
+  }
+
+  function getUint16(bytes calldata self, bytes1 pos) internal pure returns (uint16 output) {
+    assembly {
+      output := calldataload(add(self.offset, pos))
+    }
+  }
+
+  function getUint8(bytes calldata self, bytes1 pos) internal pure returns (uint8 output) {
+    assembly {
+      output := calldataload(add(self.offset, pos))
+    }
+  }
+
+  function getBool(bytes calldata self, bytes1 pos) internal pure returns (bool output) {
+    assembly {
+      output := calldataload(add(self.offset, pos))
+    }
+  }
+
+  function getBytes32(bytes calldata self, bytes1 pos) internal pure returns (bytes32 output) {
+    assembly {
+      output := calldataload(add(self.offset, pos))
+    }
+  }
+}

--- a/contracts/protocol/pool/Pool.sol
+++ b/contracts/protocol/pool/Pool.sol
@@ -450,66 +450,56 @@ contract Pool is VersionedInitializable, PoolStorage, IPool {
       MultiCallAction action = MultiCallAction(uint8(actions[i]));
       bytes calldata param = params[i];
       if (action == MultiCallAction.Supply) {
-        supply(
-          param.getAddress(),
-          param.getUint256(0x20),
-          param.getAddress(0x40),
-          param.getUint16(0x60)
-        );
+        supply(param.getAddress(), param.getUint256(1), param.getAddress(2), param.getUint16(3));
       } else if (action == MultiCallAction.Borrow) {
         borrow(
           param.getAddress(),
-          param.getUint256(0x20),
-          param.getUint256(0x40),
-          param.getUint16(0x60),
-          param.getAddress(0x80)
+          param.getUint256(1),
+          param.getUint256(2),
+          param.getUint16(3),
+          param.getAddress(4)
         );
       } else if (action == MultiCallAction.Repay) {
-        repay(
-          param.getAddress(),
-          param.getUint256(0x20),
-          param.getUint256(0x40),
-          param.getAddress(0x60)
-        );
+        repay(param.getAddress(), param.getUint256(1), param.getUint256(2), param.getAddress(3));
       } else if (action == MultiCallAction.Withdraw) {
-        withdraw(param.getAddress(), param.getUint256(0x20), param.getAddress(0x40));
+        withdraw(param.getAddress(), param.getUint256(1), param.getAddress(2));
       } else if (action == MultiCallAction.SetUserUseReserveAsCollateral) {
-        setUserUseReserveAsCollateral(param.getAddress(), param.getBool(0x20));
+        setUserUseReserveAsCollateral(param.getAddress(), param.getBool(1));
       } else if (action == MultiCallAction.SwapBorrowRateMode) {
-        swapBorrowRateMode(param.getAddress(), param.getUint256(0x20));
+        swapBorrowRateMode(param.getAddress(), param.getUint256(1));
       } else if (action == MultiCallAction.RebalanceStableBorrowRate) {
-        rebalanceStableBorrowRate(param.getAddress(), param.getAddress(0x20));
+        rebalanceStableBorrowRate(param.getAddress(), param.getAddress(1));
       } else if (action == MultiCallAction.SupplyWithPermit) {
         supplyWithPermit(
           param.getAddress(),
-          param.getUint256(0x20),
-          param.getAddress(0x40),
-          param.getUint16(0x60),
-          param.getUint256(0x80),
-          param.getUint8(0xA0),
-          param.getBytes32(0xC0),
-          param.getBytes32(0xE0)
+          param.getUint256(1),
+          param.getAddress(2),
+          param.getUint16(3),
+          param.getUint256(4),
+          param.getUint8(5),
+          param.getBytes32(6),
+          param.getBytes32(7)
         );
       } else if (action == MultiCallAction.RepayWithPermit) {
         repayWithPermit(
           param.getAddress(),
-          param.getUint256(0x20),
-          param.getUint256(0x40),
-          param.getAddress(0x60),
-          param.getUint256(0x80),
-          param.getUint8(0xA0),
-          param.getBytes32(0xC0),
-          param.getBytes32(0xE0)
+          param.getUint256(1),
+          param.getUint256(2),
+          param.getAddress(3),
+          param.getUint256(4),
+          param.getUint8(5),
+          param.getBytes32(6),
+          param.getBytes32(7)
         );
       } else if (action == MultiCallAction.RepayWithATokens) {
-        repayWithATokens(param.getAddress(), param.getUint256(0x20), param.getUint256(0x40));
+        repayWithATokens(param.getAddress(), param.getUint256(1), param.getUint256(2));
       } else if (action == MultiCallAction.LiquidationCall) {
         liquidationCall(
           param.getAddress(),
-          param.getAddress(0x20),
-          param.getAddress(0x40),
-          param.getUint256(0x60),
-          param.getBool(0x80)
+          param.getAddress(1),
+          param.getAddress(2),
+          param.getUint256(3),
+          param.getBool(4)
         );
       }
       unchecked {

--- a/contracts/protocol/pool/Pool.sol
+++ b/contracts/protocol/pool/Pool.sol
@@ -451,14 +451,14 @@ contract Pool is VersionedInitializable, PoolStorage, IPool {
       bytes calldata param = params[i];
       if (action == MultiCallAction.Supply) {
         supply(
-          param.getAddress(0x00),
+          param.getAddress(),
           param.getUint256(0x20),
           param.getAddress(0x40),
           param.getUint16(0x60)
         );
       } else if (action == MultiCallAction.Borrow) {
         borrow(
-          param.getAddress(0x00),
+          param.getAddress(),
           param.getUint256(0x20),
           param.getUint256(0x40),
           param.getUint16(0x60),
@@ -466,22 +466,22 @@ contract Pool is VersionedInitializable, PoolStorage, IPool {
         );
       } else if (action == MultiCallAction.Repay) {
         repay(
-          param.getAddress(0x00),
+          param.getAddress(),
           param.getUint256(0x20),
           param.getUint256(0x40),
           param.getAddress(0x60)
         );
       } else if (action == MultiCallAction.Withdraw) {
-        withdraw(param.getAddress(0x00), param.getUint256(0x20), param.getAddress(0x40));
+        withdraw(param.getAddress(), param.getUint256(0x20), param.getAddress(0x40));
       } else if (action == MultiCallAction.SetUserUseReserveAsCollateral) {
-        setUserUseReserveAsCollateral(param.getAddress(0x00), param.getBool(0x20));
+        setUserUseReserveAsCollateral(param.getAddress(), param.getBool(0x20));
       } else if (action == MultiCallAction.SwapBorrowRateMode) {
-        swapBorrowRateMode(param.getAddress(0x00), param.getUint256(0x20));
+        swapBorrowRateMode(param.getAddress(), param.getUint256(0x20));
       } else if (action == MultiCallAction.RebalanceStableBorrowRate) {
-        rebalanceStableBorrowRate(param.getAddress(0x00), param.getAddress(0x20));
+        rebalanceStableBorrowRate(param.getAddress(), param.getAddress(0x20));
       } else if (action == MultiCallAction.SupplyWithPermit) {
         supplyWithPermit(
-          param.getAddress(0x00),
+          param.getAddress(),
           param.getUint256(0x20),
           param.getAddress(0x40),
           param.getUint16(0x60),
@@ -492,7 +492,7 @@ contract Pool is VersionedInitializable, PoolStorage, IPool {
         );
       } else if (action == MultiCallAction.RepayWithPermit) {
         repayWithPermit(
-          param.getAddress(0x00),
+          param.getAddress(),
           param.getUint256(0x20),
           param.getUint256(0x40),
           param.getAddress(0x60),
@@ -502,10 +502,10 @@ contract Pool is VersionedInitializable, PoolStorage, IPool {
           param.getBytes32(0xE0)
         );
       } else if (action == MultiCallAction.RepayWithATokens) {
-        repayWithATokens(param.getAddress(0x00), param.getUint256(0x20), param.getUint256(0x40));
+        repayWithATokens(param.getAddress(), param.getUint256(0x20), param.getUint256(0x40));
       } else if (action == MultiCallAction.LiquidationCall) {
         liquidationCall(
-          param.getAddress(0x00),
+          param.getAddress(),
           param.getAddress(0x20),
           param.getAddress(0x40),
           param.getUint256(0x60),


### PR DESCRIPTION
MutliCall allows aave v3 users to perform multiple calls to Pool functions in a single transaction, thus saving on base gas fees. So it would make it easier for users for example:
- supply -> borrow 
- repay -> withdraw
- supply multiple assets
- withdraw multiple assets
- borrow multiple assets
- and much more...

let me know if there is anything that should be changed, I tried to write tests, but I stumbled upon 
some errors while running tests on docker.