### PR TITLE
fix: Soften solidity version of openzeppelin dependencies

### DIFF
--- a/contracts/dependencies/openzeppelin/contracts/AccessControl.sol
+++ b/contracts/dependencies/openzeppelin/contracts/AccessControl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './IAccessControl.sol';
 import './Context.sol';

--- a/contracts/dependencies/openzeppelin/contracts/Context.sol
+++ b/contracts/dependencies/openzeppelin/contracts/Context.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /*
  * @dev Provides information about the current execution context, including the

--- a/contracts/dependencies/openzeppelin/contracts/ERC165.sol
+++ b/contracts/dependencies/openzeppelin/contracts/ERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './IERC165.sol';
 

--- a/contracts/dependencies/openzeppelin/contracts/ERC20.sol
+++ b/contracts/dependencies/openzeppelin/contracts/ERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './Context.sol';
 import './IERC20.sol';

--- a/contracts/dependencies/openzeppelin/contracts/IAccessControl.sol
+++ b/contracts/dependencies/openzeppelin/contracts/IAccessControl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @dev External interface of AccessControl declared to support ERC165 detection.

--- a/contracts/dependencies/openzeppelin/contracts/IERC165.sol
+++ b/contracts/dependencies/openzeppelin/contracts/IERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface of the ERC165 standard, as defined in the

--- a/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol
+++ b/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {IERC20} from './IERC20.sol';
 

--- a/contracts/dependencies/openzeppelin/contracts/Ownable.sol
+++ b/contracts/dependencies/openzeppelin/contracts/Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './Context.sol';
 

--- a/contracts/dependencies/openzeppelin/contracts/SafeCast.sol
+++ b/contracts/dependencies/openzeppelin/contracts/SafeCast.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts v4.4.1 (utils/math/SafeCast.sol)
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Wrappers over Solidity's uintXX/intXX casting operators with added overflow

--- a/contracts/dependencies/openzeppelin/contracts/SafeMath.sol
+++ b/contracts/dependencies/openzeppelin/contracts/SafeMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /// @title Optimized overflow and underflow safe math operations
 /// @notice Contains methods for doing math operations that revert on overflow or underflow for minimal gas cost

--- a/contracts/dependencies/openzeppelin/contracts/Strings.sol
+++ b/contracts/dependencies/openzeppelin/contracts/Strings.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @dev String operations.

--- a/contracts/protocol/tokenization/base/IncentivizedERC20.sol
+++ b/contracts/protocol/tokenization/base/IncentivizedERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {Context} from '../../../dependencies/openzeppelin/contracts/Context.sol';
 import {IERC20} from '../../../dependencies/openzeppelin/contracts/IERC20.sol';


### PR DESCRIPTION
Currently it is impossible to import aave-v3-core to another project with any solidity version besides 0.8.10 because of version of openzeppelin dependencies. Some of them have fixed solidity version 0.8.10, but now they're softened