### PR TITLE
Update ReservesSetupHelper.sol: Optimized Gas

### DIFF
--- a/contracts/deployments/ReservesSetupHelper.sol
+++ b/contracts/deployments/ReservesSetupHelper.sol
@@ -13,15 +13,15 @@ import {Ownable} from '../dependencies/openzeppelin/contracts/Ownable.sol';
 contract ReservesSetupHelper is Ownable {
   struct ConfigureReserveInput {
     address asset;
+    bool stableBorrowingEnabled;
+    bool borrowingEnabled;
+    bool flashLoanEnabled;
     uint256 baseLTV;
     uint256 liquidationThreshold;
     uint256 liquidationBonus;
     uint256 reserveFactor;
     uint256 borrowCap;
     uint256 supplyCap;
-    bool stableBorrowingEnabled;
-    bool borrowingEnabled;
-    bool flashLoanEnabled;
   }
 
   /**
@@ -34,7 +34,7 @@ contract ReservesSetupHelper is Ownable {
     PoolConfigurator configurator,
     ConfigureReserveInput[] calldata inputParams
   ) external onlyOwner {
-    for (uint256 i = 0; i < inputParams.length; i++) {
+    for (uint256 i; i < inputParams.length;) {
       configurator.configureReserveAsCollateral(
         inputParams[i].asset,
         inputParams[i].baseLTV,
@@ -54,6 +54,10 @@ contract ReservesSetupHelper is Ownable {
       configurator.setReserveFlashLoaning(inputParams[i].asset, inputParams[i].flashLoanEnabled);
       configurator.setSupplyCap(inputParams[i].asset, inputParams[i].supplyCap);
       configurator.setReserveFactor(inputParams[i].asset, inputParams[i].reserveFactor);
+    }
+
+    unchecked {
+      ++i;
     }
   }
 }


### PR DESCRIPTION
Types of changes made:

1st - Struct Packing - Aligning booleans with the address in order to decrease the slots which kinds of save gas. Refer this -> https://dev.to/javier123454321/solidity-gas-optimizations-pt-3-packing-structs-23f4

2nd - `uint256 i = 0;` to `uint256 i` - This change too saves some gas cuz the default value of all unsigned integers is 0. Thus, I find no need to initialize it

3rd - using `unchecked` - After the Solidity 0.8 version, Solidity compilers started using overflow/underflow checks which is gas costly. But I find that there's no chance of any underflow/overflow in this loop, so `unchecked` can be used in this purpose. (Tho, I still suggest to take a brief look into this change)

4th - `i++` to `++i` - Saves gas, just make sure it doesn't messes up with the code's logic.

Refer this for 2nd, 3rd and 4th change -> https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#for-loops-improvement