### PR TITLE
fix: Fixes solc version of contracts

### DIFF
--- a/contracts/dependencies/gnosis/contracts/GPv2SafeERC20.sol
+++ b/contracts/dependencies/gnosis/contracts/GPv2SafeERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {IERC20} from '../../openzeppelin/contracts/IERC20.sol';
 

--- a/contracts/dependencies/openzeppelin/contracts/AccessControl.sol
+++ b/contracts/dependencies/openzeppelin/contracts/AccessControl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './IAccessControl.sol';
 import './Context.sol';

--- a/contracts/dependencies/openzeppelin/contracts/Context.sol
+++ b/contracts/dependencies/openzeppelin/contracts/Context.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /*
  * @dev Provides information about the current execution context, including the

--- a/contracts/dependencies/openzeppelin/contracts/ERC165.sol
+++ b/contracts/dependencies/openzeppelin/contracts/ERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './IERC165.sol';
 

--- a/contracts/dependencies/openzeppelin/contracts/ERC20.sol
+++ b/contracts/dependencies/openzeppelin/contracts/ERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './Context.sol';
 import './IERC20.sol';

--- a/contracts/dependencies/openzeppelin/contracts/IAccessControl.sol
+++ b/contracts/dependencies/openzeppelin/contracts/IAccessControl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @dev External interface of AccessControl declared to support ERC165 detection.

--- a/contracts/dependencies/openzeppelin/contracts/IERC165.sol
+++ b/contracts/dependencies/openzeppelin/contracts/IERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface of the ERC165 standard, as defined in the

--- a/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol
+++ b/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {IERC20} from './IERC20.sol';
 

--- a/contracts/dependencies/openzeppelin/contracts/Ownable.sol
+++ b/contracts/dependencies/openzeppelin/contracts/Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './Context.sol';
 

--- a/contracts/dependencies/openzeppelin/contracts/SafeCast.sol
+++ b/contracts/dependencies/openzeppelin/contracts/SafeCast.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts v4.4.1 (utils/math/SafeCast.sol)
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Wrappers over Solidity's uintXX/intXX casting operators with added overflow

--- a/contracts/dependencies/openzeppelin/contracts/SafeMath.sol
+++ b/contracts/dependencies/openzeppelin/contracts/SafeMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /// @title Optimized overflow and underflow safe math operations
 /// @notice Contains methods for doing math operations that revert on overflow or underflow for minimal gas cost

--- a/contracts/dependencies/openzeppelin/contracts/Strings.sol
+++ b/contracts/dependencies/openzeppelin/contracts/Strings.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @dev String operations.

--- a/contracts/dependencies/openzeppelin/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/contracts/dependencies/openzeppelin/upgradeability/AdminUpgradeabilityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './BaseAdminUpgradeabilityProxy.sol';
 

--- a/contracts/dependencies/openzeppelin/upgradeability/BaseAdminUpgradeabilityProxy.sol
+++ b/contracts/dependencies/openzeppelin/upgradeability/BaseAdminUpgradeabilityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './UpgradeabilityProxy.sol';
 

--- a/contracts/dependencies/openzeppelin/upgradeability/BaseUpgradeabilityProxy.sol
+++ b/contracts/dependencies/openzeppelin/upgradeability/BaseUpgradeabilityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './Proxy.sol';
 import '../contracts/Address.sol';

--- a/contracts/dependencies/openzeppelin/upgradeability/Initializable.sol
+++ b/contracts/dependencies/openzeppelin/upgradeability/Initializable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @title Initializable

--- a/contracts/dependencies/openzeppelin/upgradeability/InitializableAdminUpgradeabilityProxy.sol
+++ b/contracts/dependencies/openzeppelin/upgradeability/InitializableAdminUpgradeabilityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './BaseAdminUpgradeabilityProxy.sol';
 import './InitializableUpgradeabilityProxy.sol';

--- a/contracts/dependencies/openzeppelin/upgradeability/InitializableUpgradeabilityProxy.sol
+++ b/contracts/dependencies/openzeppelin/upgradeability/InitializableUpgradeabilityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './BaseUpgradeabilityProxy.sol';
 

--- a/contracts/dependencies/openzeppelin/upgradeability/Proxy.sol
+++ b/contracts/dependencies/openzeppelin/upgradeability/Proxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @title Proxy

--- a/contracts/dependencies/openzeppelin/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/dependencies/openzeppelin/upgradeability/UpgradeabilityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import './BaseUpgradeabilityProxy.sol';
 

--- a/contracts/dependencies/weth/WETH9.sol
+++ b/contracts/dependencies/weth/WETH9.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 contract WETH9 {
   string public name = 'Wrapped Ether';

--- a/contracts/deployments/ReservesSetupHelper.sol
+++ b/contracts/deployments/ReservesSetupHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {PoolConfigurator} from '../protocol/pool/PoolConfigurator.sol';
 import {Ownable} from '../dependencies/openzeppelin/contracts/Ownable.sol';

--- a/contracts/flashloan/base/FlashLoanReceiverBase.sol
+++ b/contracts/flashloan/base/FlashLoanReceiverBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 import {IFlashLoanReceiver} from '../interfaces/IFlashLoanReceiver.sol';
 import {IPoolAddressesProvider} from '../../interfaces/IPoolAddressesProvider.sol';

--- a/contracts/flashloan/base/FlashLoanSimpleReceiverBase.sol
+++ b/contracts/flashloan/base/FlashLoanSimpleReceiverBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 import {IFlashLoanSimpleReceiver} from '../interfaces/IFlashLoanSimpleReceiver.sol';
 import {IPoolAddressesProvider} from '../../interfaces/IPoolAddressesProvider.sol';

--- a/contracts/misc/AaveOracle.sol
+++ b/contracts/misc/AaveOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {AggregatorInterface} from '../dependencies/chainlink/AggregatorInterface.sol';
 import {Errors} from '../protocol/libraries/helpers/Errors.sol';

--- a/contracts/misc/AaveProtocolDataProvider.sol
+++ b/contracts/misc/AaveProtocolDataProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC20Detailed} from '../dependencies/openzeppelin/contracts/IERC20Detailed.sol';
 import {ReserveConfiguration} from '../protocol/libraries/configuration/ReserveConfiguration.sol';

--- a/contracts/misc/L2Encoder.sol
+++ b/contracts/misc/L2Encoder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {SafeCast} from '../dependencies/openzeppelin/contracts/SafeCast.sol';
 import {IPool} from '../interfaces/IPool.sol';

--- a/contracts/misc/ZeroReserveInterestRateStrategy.sol
+++ b/contracts/misc/ZeroReserveInterestRateStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.10;
 
 import {DataTypes} from '../protocol/libraries/types/DataTypes.sol';
 import {IDefaultInterestRateStrategy} from '../interfaces/IDefaultInterestRateStrategy.sol';

--- a/contracts/mocks/flashloan/MockFlashLoanReceiver.sol
+++ b/contracts/mocks/flashloan/MockFlashLoanReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {GPv2SafeERC20} from '../../dependencies/gnosis/contracts/GPv2SafeERC20.sol';

--- a/contracts/mocks/flashloan/MockSimpleFlashLoanReceiver.sol
+++ b/contracts/mocks/flashloan/MockSimpleFlashLoanReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {SafeMath} from '../../dependencies/openzeppelin/contracts/SafeMath.sol';
 import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';

--- a/contracts/mocks/helpers/MockIncentivesController.sol
+++ b/contracts/mocks/helpers/MockIncentivesController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {IAaveIncentivesController} from '../../interfaces/IAaveIncentivesController.sol';
 

--- a/contracts/mocks/helpers/MockL2Pool.sol
+++ b/contracts/mocks/helpers/MockL2Pool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {IPoolAddressesProvider} from '../../interfaces/IPoolAddressesProvider.sol';
 import {L2Pool} from '../../protocol/pool/L2Pool.sol';

--- a/contracts/mocks/helpers/MockPeripheryContract.sol
+++ b/contracts/mocks/helpers/MockPeripheryContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 contract MockPeripheryContractV1 {
   address private _manager;

--- a/contracts/mocks/helpers/MockPool.sol
+++ b/contracts/mocks/helpers/MockPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {IPoolAddressesProvider} from '../../interfaces/IPoolAddressesProvider.sol';
 

--- a/contracts/mocks/helpers/MockReserveConfiguration.sol
+++ b/contracts/mocks/helpers/MockReserveConfiguration.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {ReserveConfiguration} from '../../protocol/libraries/configuration/ReserveConfiguration.sol';
 import {DataTypes} from '../../protocol/libraries/types/DataTypes.sol';

--- a/contracts/mocks/helpers/SelfDestructTransfer.sol
+++ b/contracts/mocks/helpers/SelfDestructTransfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 contract SelfdestructTransfer {
   function destroyAndTransfer(address payable to) external payable {

--- a/contracts/mocks/oracle/CLAggregators/MockAggregator.sol
+++ b/contracts/mocks/oracle/CLAggregators/MockAggregator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 contract MockAggregator {
   int256 private _latestAnswer;

--- a/contracts/mocks/oracle/PriceOracle.sol
+++ b/contracts/mocks/oracle/PriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {IPriceOracle} from '../../interfaces/IPriceOracle.sol';
 

--- a/contracts/mocks/oracle/SequencerOracle.sol
+++ b/contracts/mocks/oracle/SequencerOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {Ownable} from '../../dependencies/openzeppelin/contracts/Ownable.sol';
 import {ISequencerOracle} from '../../interfaces/ISequencerOracle.sol';

--- a/contracts/mocks/tests/FlashloanAttacker.sol
+++ b/contracts/mocks/tests/FlashloanAttacker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {SafeMath} from '../../dependencies/openzeppelin/contracts/SafeMath.sol';
 import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';

--- a/contracts/mocks/tests/MockReserveInterestRateStrategy.sol
+++ b/contracts/mocks/tests/MockReserveInterestRateStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {IDefaultInterestRateStrategy} from '../../interfaces/IDefaultInterestRateStrategy.sol';
 import {IPoolAddressesProvider} from '../../interfaces/IPoolAddressesProvider.sol';

--- a/contracts/mocks/tests/WadRayMathWrapper.sol
+++ b/contracts/mocks/tests/WadRayMathWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {WadRayMath} from '../../protocol/libraries/math/WadRayMath.sol';
 

--- a/contracts/mocks/tokens/MintableDelegationERC20.sol
+++ b/contracts/mocks/tokens/MintableDelegationERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {ERC20} from '../../dependencies/openzeppelin/contracts/ERC20.sol';
 import {IDelegationToken} from '../../interfaces/IDelegationToken.sol';

--- a/contracts/mocks/tokens/MintableERC20.sol
+++ b/contracts/mocks/tokens/MintableERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {ERC20} from '../../dependencies/openzeppelin/contracts/ERC20.sol';
 import {IERC20WithPermit} from '../../interfaces/IERC20WithPermit.sol';

--- a/contracts/mocks/tokens/MockATokenRepayment.sol
+++ b/contracts/mocks/tokens/MockATokenRepayment.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {AToken} from '../../protocol/tokenization/AToken.sol';
 import {IPool} from '../../interfaces/IPool.sol';

--- a/contracts/mocks/tokens/WETH9Mocked.sol
+++ b/contracts/mocks/tokens/WETH9Mocked.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {WETH9} from '../../dependencies/weth/WETH9.sol';
 

--- a/contracts/mocks/upgradeability/MockAToken.sol
+++ b/contracts/mocks/upgradeability/MockAToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {AToken} from '../../protocol/tokenization/AToken.sol';
 import {IPool} from '../../interfaces/IPool.sol';

--- a/contracts/mocks/upgradeability/MockInitializableImplementation.sol
+++ b/contracts/mocks/upgradeability/MockInitializableImplementation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {VersionedInitializable} from '../../protocol/libraries/aave-upgradeability/VersionedInitializable.sol';
 

--- a/contracts/mocks/upgradeability/MockStableDebtToken.sol
+++ b/contracts/mocks/upgradeability/MockStableDebtToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {StableDebtToken} from '../../protocol/tokenization/StableDebtToken.sol';
 import {IPool} from '../../interfaces/IPool.sol';

--- a/contracts/mocks/upgradeability/MockVariableDebtToken.sol
+++ b/contracts/mocks/upgradeability/MockVariableDebtToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {VariableDebtToken} from '../../protocol/tokenization/VariableDebtToken.sol';
 import {IPool} from '../../interfaces/IPool.sol';

--- a/contracts/protocol/configuration/ACLManager.sol
+++ b/contracts/protocol/configuration/ACLManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {AccessControl} from '../../dependencies/openzeppelin/contracts/AccessControl.sol';
 import {IPoolAddressesProvider} from '../../interfaces/IPoolAddressesProvider.sol';

--- a/contracts/protocol/configuration/PoolAddressesProvider.sol
+++ b/contracts/protocol/configuration/PoolAddressesProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {Ownable} from '../../dependencies/openzeppelin/contracts/Ownable.sol';
 import {IPoolAddressesProvider} from '../../interfaces/IPoolAddressesProvider.sol';

--- a/contracts/protocol/configuration/PoolAddressesProviderRegistry.sol
+++ b/contracts/protocol/configuration/PoolAddressesProviderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {Ownable} from '../../dependencies/openzeppelin/contracts/Ownable.sol';
 import {Errors} from '../libraries/helpers/Errors.sol';

--- a/contracts/protocol/configuration/PriceOracleSentinel.sol
+++ b/contracts/protocol/configuration/PriceOracleSentinel.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {Errors} from '../libraries/helpers/Errors.sol';
 import {IPoolAddressesProvider} from '../../interfaces/IPoolAddressesProvider.sol';

--- a/contracts/protocol/libraries/aave-upgradeability/BaseImmutableAdminUpgradeabilityProxy.sol
+++ b/contracts/protocol/libraries/aave-upgradeability/BaseImmutableAdminUpgradeabilityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {BaseUpgradeabilityProxy} from '../../../dependencies/openzeppelin/upgradeability/BaseUpgradeabilityProxy.sol';
 

--- a/contracts/protocol/libraries/aave-upgradeability/InitializableImmutableAdminUpgradeabilityProxy.sol
+++ b/contracts/protocol/libraries/aave-upgradeability/InitializableImmutableAdminUpgradeabilityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 import {InitializableUpgradeabilityProxy} from '../../../dependencies/openzeppelin/upgradeability/InitializableUpgradeabilityProxy.sol';
 import {Proxy} from '../../../dependencies/openzeppelin/upgradeability/Proxy.sol';

--- a/contracts/protocol/libraries/aave-upgradeability/VersionedInitializable.sol
+++ b/contracts/protocol/libraries/aave-upgradeability/VersionedInitializable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.10;
+pragma solidity ^0.8.0;
 
 /**
  * @title VersionedInitializable

--- a/contracts/protocol/libraries/logic/BorrowLogic.sol
+++ b/contracts/protocol/libraries/logic/BorrowLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {GPv2SafeERC20} from '../../../dependencies/gnosis/contracts/GPv2SafeERC20.sol';
 import {SafeCast} from '../../../dependencies/openzeppelin/contracts/SafeCast.sol';

--- a/contracts/protocol/libraries/logic/BridgeLogic.sol
+++ b/contracts/protocol/libraries/logic/BridgeLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC20} from '../../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {GPv2SafeERC20} from '../../../dependencies/gnosis/contracts/GPv2SafeERC20.sol';

--- a/contracts/protocol/libraries/logic/CalldataLogic.sol
+++ b/contracts/protocol/libraries/logic/CalldataLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 /**
  * @title CalldataLogic library

--- a/contracts/protocol/libraries/logic/ConfiguratorLogic.sol
+++ b/contracts/protocol/libraries/logic/ConfiguratorLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IPool} from '../../../interfaces/IPool.sol';
 import {IInitializableAToken} from '../../../interfaces/IInitializableAToken.sol';

--- a/contracts/protocol/libraries/logic/EModeLogic.sol
+++ b/contracts/protocol/libraries/logic/EModeLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {GPv2SafeERC20} from '../../../dependencies/gnosis/contracts/GPv2SafeERC20.sol';
 import {IERC20} from '../../../dependencies/openzeppelin/contracts/IERC20.sol';

--- a/contracts/protocol/libraries/logic/FlashLoanLogic.sol
+++ b/contracts/protocol/libraries/logic/FlashLoanLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {GPv2SafeERC20} from '../../../dependencies/gnosis/contracts/GPv2SafeERC20.sol';
 import {SafeCast} from '../../../dependencies/openzeppelin/contracts/SafeCast.sol';

--- a/contracts/protocol/libraries/logic/GenericLogic.sol
+++ b/contracts/protocol/libraries/logic/GenericLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC20} from '../../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {IScaledBalanceToken} from '../../../interfaces/IScaledBalanceToken.sol';

--- a/contracts/protocol/libraries/logic/IsolationModeLogic.sol
+++ b/contracts/protocol/libraries/logic/IsolationModeLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {DataTypes} from '../types/DataTypes.sol';
 import {ReserveConfiguration} from '../configuration/ReserveConfiguration.sol';

--- a/contracts/protocol/libraries/logic/LiquidationLogic.sol
+++ b/contracts/protocol/libraries/logic/LiquidationLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC20} from '../../../dependencies/openzeppelin/contracts//IERC20.sol';
 import {GPv2SafeERC20} from '../../../dependencies/gnosis/contracts/GPv2SafeERC20.sol';

--- a/contracts/protocol/libraries/logic/PoolLogic.sol
+++ b/contracts/protocol/libraries/logic/PoolLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {GPv2SafeERC20} from '../../../dependencies/gnosis/contracts/GPv2SafeERC20.sol';
 import {Address} from '../../../dependencies/openzeppelin/contracts/Address.sol';

--- a/contracts/protocol/libraries/logic/ReserveLogic.sol
+++ b/contracts/protocol/libraries/logic/ReserveLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC20} from '../../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {GPv2SafeERC20} from '../../../dependencies/gnosis/contracts/GPv2SafeERC20.sol';

--- a/contracts/protocol/libraries/logic/SupplyLogic.sol
+++ b/contracts/protocol/libraries/logic/SupplyLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC20} from '../../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {GPv2SafeERC20} from '../../../dependencies/gnosis/contracts/GPv2SafeERC20.sol';

--- a/contracts/protocol/libraries/logic/ValidationLogic.sol
+++ b/contracts/protocol/libraries/logic/ValidationLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC20} from '../../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {Address} from '../../../dependencies/openzeppelin/contracts/Address.sol';

--- a/contracts/protocol/pool/DefaultReserveInterestRateStrategy.sol
+++ b/contracts/protocol/pool/DefaultReserveInterestRateStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.10;
 
 import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {WadRayMath} from '../libraries/math/WadRayMath.sol';

--- a/contracts/protocol/pool/Pool.sol
+++ b/contracts/protocol/pool/Pool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {VersionedInitializable} from '../libraries/aave-upgradeability/VersionedInitializable.sol';
 import {Errors} from '../libraries/helpers/Errors.sol';

--- a/contracts/protocol/pool/PoolConfigurator.sol
+++ b/contracts/protocol/pool/PoolConfigurator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {VersionedInitializable} from '../libraries/aave-upgradeability/VersionedInitializable.sol';
 import {ReserveConfiguration} from '../libraries/configuration/ReserveConfiguration.sol';

--- a/contracts/protocol/pool/PoolStorage.sol
+++ b/contracts/protocol/pool/PoolStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {UserConfiguration} from '../libraries/configuration/UserConfiguration.sol';
 import {ReserveConfiguration} from '../libraries/configuration/ReserveConfiguration.sol';

--- a/contracts/protocol/tokenization/AToken.sol
+++ b/contracts/protocol/tokenization/AToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {GPv2SafeERC20} from '../../dependencies/gnosis/contracts/GPv2SafeERC20.sol';

--- a/contracts/protocol/tokenization/DelegationAwareAToken.sol
+++ b/contracts/protocol/tokenization/DelegationAwareAToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IPool} from '../../interfaces/IPool.sol';
 import {IDelegationToken} from '../../interfaces/IDelegationToken.sol';

--- a/contracts/protocol/tokenization/StableDebtToken.sol
+++ b/contracts/protocol/tokenization/StableDebtToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {VersionedInitializable} from '../libraries/aave-upgradeability/VersionedInitializable.sol';

--- a/contracts/protocol/tokenization/VariableDebtToken.sol
+++ b/contracts/protocol/tokenization/VariableDebtToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {SafeCast} from '../../dependencies/openzeppelin/contracts/SafeCast.sol';

--- a/contracts/protocol/tokenization/base/DebtTokenBase.sol
+++ b/contracts/protocol/tokenization/base/DebtTokenBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {Context} from '../../../dependencies/openzeppelin/contracts/Context.sol';
 import {Errors} from '../../libraries/helpers/Errors.sol';

--- a/contracts/protocol/tokenization/base/EIP712Base.sol
+++ b/contracts/protocol/tokenization/base/EIP712Base.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 /**
  * @title EIP712Base

--- a/contracts/protocol/tokenization/base/IncentivizedERC20.sol
+++ b/contracts/protocol/tokenization/base/IncentivizedERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {Context} from '../../../dependencies/openzeppelin/contracts/Context.sol';
 import {IERC20} from '../../../dependencies/openzeppelin/contracts/IERC20.sol';

--- a/contracts/protocol/tokenization/base/MintableIncentivizedERC20.sol
+++ b/contracts/protocol/tokenization/base/MintableIncentivizedERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IAaveIncentivesController} from '../../../interfaces/IAaveIncentivesController.sol';
 import {IPool} from '../../../interfaces/IPool.sol';

--- a/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol
+++ b/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {SafeCast} from '../../../dependencies/openzeppelin/contracts/SafeCast.sol';
 import {Errors} from '../../libraries/helpers/Errors.sol';


### PR DESCRIPTION
Closes #919 

In general, the reasoning is the following:
1. interfaces and libraries to ^0.8.0
2. dependencies and mocks to ^0.8.0
3. contracts to ^0.8.10


Here is how it looks now:
- dependencies/chainlink to ^0.8.0
- dependencies/gnosis/GPv2SafeERC20 to ^0.8.0
- dependencies/openzeppelin/contracts to ^0.8.0
- dependencies/openzeppelin/upgradeability to ^0.8.0
- dependencies/weth to ^0.8.0 
- deployments to ^0.8.0
- flashloan/interfaces to ^0.8.0
- flashloan/base to ^0.8.0
- interfaces to ^0.8.0
- misc/interfaces to ^0.8.0
- misc to * ^0.8.10
- mocks to ^0.8.0
- protocol/configuration to ^0.8.10
- protocol/libraries/aave-upgradeability to ^0.8.0
- protocol/libraries/configuration to ^0.8.0
- protocol/libraries/helpers to ^0.8.0
- protocol/libraries/logic to ^0.8.10
- protocol/libraries/math to ^0.8.0
- protocol/libraries/types to ^0.8.0
- protocol/pool to ^0.8.10
- protocol/tokenization to ^0.8.10